### PR TITLE
Add SQL Server connection string builder

### DIFF
--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Database/SqlServerConnectionStringBuilderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Database/SqlServerConnectionStringBuilderTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Data.SqlClient;
+using Energinet.DataHub.Core.FunctionApp.TestCommon.Database;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Database
+{
+    public class SqlServerConnectionStringBuilderTests
+    {
+        public class LocalDb
+        {
+            [Fact]
+            public void When_DatabaseNameIsSupplied_Then_ItIsPartOfReturnedConnectionString()
+            {
+                // Arrange
+                var builder = SqlServerConnectionStringBuilder.MSSQLLocalDb;
+                var databaseName = Guid.NewGuid().ToString("N");
+
+                // Act
+                var connectionString = new SqlConnectionStringBuilder(builder.BuildConnectionString(databaseName));
+
+                // Assert
+                connectionString.InitialCatalog.Should().Be(databaseName);
+                connectionString.IntegratedSecurity.Should().BeTrue();
+            }
+
+            [Fact]
+            public void When_ConnectionStringIsBuilt_Then_TimeoutIs3Seconds()
+            {
+                var builder = SqlServerConnectionStringBuilder.MSSQLLocalDb;
+                var databaseName = Guid.NewGuid().ToString("N");
+
+                var connectionString = new SqlConnectionStringBuilder(builder.BuildConnectionString(databaseName));
+
+                connectionString.ConnectTimeout.Should().Be(3);
+            }
+
+            [Fact]
+            public void When_ConnectionStringIsBuilt_Then_DataSourceIsForLocalDb()
+            {
+                // Arrange
+                var builder = SqlServerConnectionStringBuilder.MSSQLLocalDb;
+                const string dataSource = "(LocalDB)\\MSSQLLocalDB";
+
+                // Act
+                var connectionString = new SqlConnectionStringBuilder(builder.BuildConnectionString(Guid.NewGuid().ToString("N")));
+
+                // Assert
+                connectionString.DataSource.Should().Be(dataSource);
+            }
+
+            [Fact]
+            public void When_ConnectionStringIsBuilt_Then_IntegratedSecurityIsTrue()
+            {
+                // Arrange
+                var builder = SqlServerConnectionStringBuilder.MSSQLLocalDb;
+
+                // Act
+                var connectionString = new SqlConnectionStringBuilder(builder.BuildConnectionString(Guid.NewGuid().ToString("N")));
+
+                // Assert
+                connectionString.IntegratedSecurity.Should().BeTrue();
+            }
+        }
+
+        public class SqlServerUsernamePassword
+        {
+            [Fact]
+            public void When_HostIsSupplied_Then_ItIsPartOfTheConnectionString()
+            {
+                var parameters = GetParameters();
+                var builder = new SqlServerUsernamePasswordBuilder(parameters.Host, parameters.Username, parameters.Password);
+
+                var connectionString =
+                    new SqlConnectionStringBuilder(builder.BuildConnectionString(parameters.DatabaseName));
+
+                connectionString.DataSource.Should().Be(parameters.Host);
+            }
+
+            [Fact]
+            public void When_CredentialsIsSupplied_Then_ItIsPresent()
+            {
+                var opt = GetParameters();
+                var builder = new SqlServerUsernamePasswordBuilder(opt.Host, opt.Username, opt.Password);
+
+                var connectionString = new SqlConnectionStringBuilder(builder.BuildConnectionString(opt.DatabaseName));
+
+                connectionString.UserID.Should().Be(opt.Username);
+                connectionString.Password.Should().Be(opt.Password);
+            }
+
+            [Fact]
+            public void When_DatabaseNameIsSupplied_Then_ItIsPartOfTheConnectionString()
+            {
+                var opt = GetParameters();
+                var builder = new SqlServerUsernamePasswordBuilder(opt.Host, opt.Username, opt.Password);
+
+                var connectionString = new SqlConnectionStringBuilder(builder.BuildConnectionString(opt.DatabaseName));
+
+                connectionString.InitialCatalog.Should().Be(opt.DatabaseName);
+            }
+
+            private static (string Host, string Username, string Password, string DatabaseName) GetParameters()
+                =>
+                (Guid.NewGuid().ToString("N"),
+                 Guid.NewGuid().ToString("N"),
+                 Guid.NewGuid().ToString("N"),
+                 Guid.NewGuid().ToString("N"));
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerConnectionStringBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerConnectionStringBuilder.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
+{
+    /// <summary>
+    /// Builds a connection string for a database name
+    /// </summary>
+    public abstract class SqlServerConnectionStringBuilder
+    {
+        /// <summary>
+        /// Create a connection string for a given database
+        /// </summary>
+        /// <param name="databaseName">name of database</param>
+        /// <returns>Connection string for said database</returns>
+        public abstract string BuildConnectionString(string databaseName);
+
+        /// <summary>
+        /// Returns a builder for LocalDb with a default timeout of 3 seconds with integrated security
+        /// </summary>
+        public static SqlServerConnectionStringBuilder MSSQLLocalDb => new SqlServerLocalDb();
+
+        private class SqlServerLocalDb : SqlServerConnectionStringBuilder
+        {
+            public override string BuildConnectionString(string databaseName)
+            {
+                if (databaseName == null) throw new ArgumentNullException(nameof(databaseName));
+                return
+                    $"Data Source=(LocalDB)\\MSSQLLocalDB;Integrated Security=true;Database={databaseName};Connection Timeout=3";
+            }
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerDatabaseManager.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerDatabaseManager.cs
@@ -33,16 +33,25 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
         where TContextImplementation : DbContext
     {
         public const string DefaultCollationName = "SQL_Latin1_General_CP1_CI_AS";
+        private readonly SqlServerConnectionStringBuilder _connectionStringBuilder;
 
-        protected SqlServerDatabaseManager(string prefixForDatabaseName)
+        protected SqlServerDatabaseManager(
+            string prefixForDatabaseName,
+            SqlServerConnectionStringBuilder connectionStringBuilder)
         {
             if (string.IsNullOrWhiteSpace(prefixForDatabaseName))
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(prefixForDatabaseName));
             }
 
-            ConnectionString = BuildConnectionString(prefixForDatabaseName);
+            _connectionStringBuilder = connectionStringBuilder;
+
+            ConnectionString = BuildConnectionString(prefixForDatabaseName, connectionStringBuilder);
         }
+
+        protected SqlServerDatabaseManager(string prefixForDatabaseName)
+            : this(prefixForDatabaseName, SqlServerConnectionStringBuilder.MSSQLLocalDb)
+        { }
 
         public string ConnectionString { get; }
 
@@ -129,7 +138,7 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
         ///
         /// Connect to master database and create a database without schema.
         /// </summary>
-        private static void CreateLocalDatabaseWithoutSchema(TContextImplementation context)
+        private void CreateLocalDatabaseWithoutSchema(TContextImplementation context)
         {
             // Overview of all exception numbers: https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2008-r2/cc645603(v=sql.105)?redirectedfrom=MSDN
             const int dbNameAlreadyExistsExceptionNumber = 1801;
@@ -159,7 +168,8 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
             retryPolicy.Execute(
                 (ctx, ct) =>
                 {
-                    using var masterDbConnection = new SqlConnection(@"Data Source=(LocalDB)\MSSQLLocalDB;Initial Catalog=master;Integrated Security=True;");
+                    var masterDbConnectionString = _connectionStringBuilder.BuildConnectionString("master");
+                    using var masterDbConnection = new SqlConnection(masterDbConnectionString);
                     using var command = new SqlCommand(createDatabaseCommandText, masterDbConnection);
                     masterDbConnection.Open();
                     try
@@ -200,12 +210,10 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
         /// <summary>
         /// We create a unique database name to ensure tests using this fixture has their own database.
         /// </summary>
-        private static string BuildConnectionString(string prefixForDatabaseName)
+        private static string BuildConnectionString(string prefixForDatabaseName, SqlServerConnectionStringBuilder builder)
         {
             var databaseName = $"{prefixForDatabaseName}Database_{Guid.NewGuid()}";
-
-            // If Connection Timeout=3 is not set, tests that connect to a database that don't exists will take about 10 sec.
-            return $"Data Source=(LocalDB)\\MSSQLLocalDB;Integrated Security=true;Database={databaseName};Connection Timeout=3";
+            return builder.BuildConnectionString(databaseName);
         }
     }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerUsernamePasswordBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerUsernamePasswordBuilder.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
+{
+    public class SqlServerUsernamePasswordBuilder : SqlServerConnectionStringBuilder
+    {
+        private readonly string _host;
+        private readonly string _username;
+        private readonly string _password;
+
+        public SqlServerUsernamePasswordBuilder(string host, string username, string password)
+        {
+            _host = host ?? throw new ArgumentNullException(nameof(host));
+            _username = username ?? throw new ArgumentNullException(nameof(username));
+            _password = password ?? throw new ArgumentNullException(nameof(password));
+        }
+
+        public override string BuildConnectionString(string databaseName)
+        {
+            if (databaseName == null) throw new ArgumentNullException(nameof(databaseName));
+
+            return $"Server={_host};Database={databaseName};User Id={_username};Password={_password};";
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>1.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.3.1$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

`SqlServerDatabaseManager` is built only to support MSSQLLocalDb. This pull request is extending on this behaviour. Default is to use MSSQLLocalDb, but the behaviour can be changed by constructor injection. 

If a developer would like to use this on a stand alone sql server, then it can be done by suppling a different implementation of `SqlServerConnectionStringBuilder`