### PR TITLE
TestCommon: add AutoMoqDataAttribute and InlineAutoMoqDataAttribute

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,10 @@
 # TestCommon Release notes
 
+## Version 1.4.0
+
+- Add `AutoMoqDataAttribute` which enables auto mocking of test parameters.
+- Add `InlineAutoMoqDataAttribute` which enables the possibility to inject dependencies in tests as parameters.
+
 ## Version 1.3.0
 
 - Implemented `FunctionAppHostManager.RestartHostIfChanges(IEnumerable<KeyValuePair<string, string>> environmentVariables)` that only restarts the function app if process environment variables has changed.

--- a/source/TestCommon/source/TestCommon.Tests/Unit/AutoFixture/AttributeTests/AutoMoqClass.cs
+++ b/source/TestCommon/source/TestCommon.Tests/Unit/AutoFixture/AttributeTests/AutoMoqClass.cs
@@ -1,0 +1,33 @@
+﻿// // Copyright 2020 Energinet DataHub A/S
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License2");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+using System;
+
+namespace Energinet.DataHub.Core.TestCommon.Tests.Unit.AutoFixture.AttributeTests
+{
+    public class AutoMoqClass
+    {
+        public AutoMoqObject Add(AutoMoqObject autoMoqObject, int number)
+        {
+            autoMoqObject.Number = autoMoqObject.Number + number;
+            return autoMoqObject;
+        }
+
+        public int RandomNumber()
+        {
+            var rand = new Random();
+            return rand.Next(1, 100);
+        }
+    }
+}

--- a/source/TestCommon/source/TestCommon.Tests/Unit/AutoFixture/AttributeTests/AutoMoqDataAttributeTests.cs
+++ b/source/TestCommon/source/TestCommon.Tests/Unit/AutoFixture/AttributeTests/AutoMoqDataAttributeTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using AutoFixture.Xunit2;
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.Core.TestCommon.Tests.Unit.AutoFixture.AttributeTests
+{
+    public class AutoMoqDataAttributeTests
+    {
+        [Theory]
+        [AutoMoqData]
+        public void When_ParameterInTestIsPresent_Then_TheyAreNotNull(
+            [Frozen] AutoMoqObject autoMoqObject,
+            AutoMoqClass sut)
+        {
+            // Assert
+            autoMoqObject.Should().NotBeNull();
+            sut.Should().NotBeNull();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public void When_ParameterInTestIsPresent_Then_SutCanBeUsed(
+            [Frozen] AutoMoqObject autoMoqObject,
+            AutoMoqClass sut)
+        {
+            // Arrange
+            var addNumber = 1;
+            var expected = autoMoqObject.Number + 1;
+
+            // Act
+            var result = sut.Add(autoMoqObject, addNumber);
+
+            // Assert
+            result.Number.Should().Be(expected);
+        }
+    }
+}

--- a/source/TestCommon/source/TestCommon.Tests/Unit/AutoFixture/AttributeTests/AutoMoqObject.cs
+++ b/source/TestCommon/source/TestCommon.Tests/Unit/AutoFixture/AttributeTests/AutoMoqObject.cs
@@ -1,0 +1,21 @@
+﻿// // Copyright 2020 Energinet DataHub A/S
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License2");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+namespace Energinet.DataHub.Core.TestCommon.Tests.Unit.AutoFixture.AttributeTests
+{
+    public class AutoMoqObject
+    {
+        public int Number { get; set; }
+    }
+}

--- a/source/TestCommon/source/TestCommon.Tests/Unit/AutoFixture/AttributeTests/InlineAutoMoqDataAttributeTests.cs
+++ b/source/TestCommon/source/TestCommon.Tests/Unit/AutoFixture/AttributeTests/InlineAutoMoqDataAttributeTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.Core.TestCommon.Tests.Unit.AutoFixture.AttributeTests
+{
+    public class InlineAutoMoqDataAttributeTests
+    {
+        [Theory]
+        [InlineAutoMoqData]
+        public void When_ParameterInTestIsPresent_Then_SutCanBeUsed(AutoMoqClass sut)
+        {
+            // Act
+            var rand = sut.RandomNumber();
+
+            // Assert
+            rand.Should().BeOfType(typeof(int));
+            rand.Should().BeGreaterThan(0);
+        }
+    }
+}

--- a/source/TestCommon/source/TestCommon/AutoFixture/Attributes/AutoMoqDataAttribute.cs
+++ b/source/TestCommon/source/TestCommon/AutoFixture/Attributes/AutoMoqDataAttribute.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Xunit2;
+using MicroElements.AutoFixture.NodaTime;
+
+namespace Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes
+{
+    public class AutoMoqDataAttribute : AutoDataAttribute
+    {
+        public AutoMoqDataAttribute()
+            : base(() =>
+            {
+                var fixture = new Fixture();
+                fixture.Customize(
+                    new CompositeCustomization(
+                        new AutoMoqCustomization(),
+                        new NodaTimeCustomization()));
+
+                fixture.Behaviors.Add(new OmitOnRecursionBehavior(1));
+
+                return fixture;
+            })
+        {
+        }
+    }
+}

--- a/source/TestCommon/source/TestCommon/AutoFixture/Attributes/InlineAutoMoqDataAttribute.cs
+++ b/source/TestCommon/source/TestCommon/AutoFixture/Attributes/InlineAutoMoqDataAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using AutoFixture.Xunit2;
+
+namespace Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes
+{
+    public class InlineAutoMoqDataAttribute : InlineAutoDataAttribute
+    {
+        public InlineAutoMoqDataAttribute(params object[] objects)
+            : base(new AutoMoqDataAttribute(), objects) { }
+    }
+}

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>1.3.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.4.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>
@@ -76,6 +76,7 @@ limitations under the License.
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="MicroElements.AutoFixture.NodaTime" Version="1.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/green-energy-hub) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
To help with ease-of-use when creating unit tests, I have added two attributes to `TestCommon` that enables the user to add parameters to a unit test, that is ready for use without the need to specifically creating either new instances or mocks of those.

- Add `AutoMoqDataAttribute`
- Add `InlineAutoMoqDataAttribute`
