### PR TITLE
Link to supported Azure CLI in TestCommon documentation

### DIFF
--- a/source/TestCommon/documents/functionapp-testcommon.md
+++ b/source/TestCommon/documents/functionapp-testcommon.md
@@ -104,7 +104,8 @@ Some developer machines have SQL local DB installed already. We only need to do 
 #### Running integration tests in JetBrains Rider
 
 In order to be able to run integration tests in Rider you must have the "Azure Toolkit for Rider" plugin installed. When logging in through `Tools > Azure > Azure Log In` you get the option of using Azure CLI. This way Rider looks for the accessTokens.json file containing authentication tokens to access the resources in you subscription.
-As of version 2.30.0 of the Azure CLI the `az login` command no longer creates the accessTokens.json file needed for Rider to access your subscription. Hence version 2.29.2 or earlier must be installed to get access to your subscriptions through Rider.
+
+As of version 2.30.0 of the Azure CLI the `az login` command no longer creates the accessTokens.json file needed for Rider to access your subscription. Hence [Azure CLI version 2.29.2](https://github.com/Azure/azure-cli/releases/download/azure-cli-2.29.2/azure-cli-2.29.2.msi) or earlier must be installed to get access to your subscriptions through Rider.
 
 ## Concept
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/green-energy-hub) before we can accept your contribution. --->

## Description

Azure CLI version 2.3 and higher is (still) not supported for `az login` in JetBrains Rider. This pull request updates the  TestCommon documentation with a link to the latest supported version.