### PR TITLE
Locate custom xml prefix

### DIFF
--- a/source/XmlConversion/source/XmlConverter.Tests/XmlPrefixTests.cs
+++ b/source/XmlConversion/source/XmlConverter.Tests/XmlPrefixTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Xml.Linq;
+using Energinet.DataHub.Core.XmlConversion.XmlConverter.Configuration;
+using Xunit;
+
+namespace Energinet.DataHub.Core.XmlConversion.XmlConverter.Tests
+{
+    public class XmlPrefixTests
+    {
+        [Fact]
+        public void Converting_xml_should_support_custom_xml_namespace_prefix()
+        {
+            var mapper = new XmlMapper(_ => new HeroMapper(), _ => "Superhero");
+            var document = XmlContent.GetXDocumentWithRandomPrefix();
+
+            if (document.Root == null) throw new NullReferenceException("No root element found");
+            _ = mapper.Map(document.Root); // This method throws an ArgumentException if it can not handle the prefix
+        }
+
+        internal record Hero(string Name);
+
+        internal class HeroMapper : XmlMappingConfigurationBase
+        {
+            public HeroMapper()
+            {
+                CreateMapping<Hero>("groot", map => map
+                    .AddProperty(x => x.Name, "hero"));
+            }
+        }
+
+        private static class XmlContent
+        {
+            private const string RandomPrefix = @"
+<#REPLACE#:groot xmlns:#REPLACE#=""urn:ebix.org:structure:heros:0:1"">
+    <#REPLACE#:hero>Starlord</#REPLACE#:hero>
+</#REPLACE#:groot>";
+
+            public static XDocument GetXDocumentWithRandomPrefix()
+                => XDocument.Parse(GetXmlContentWithRandomPrefix());
+
+            public static string GetXmlContentWithRandomPrefix()
+                => CreateContent(Guid.NewGuid().ToString("N"));
+
+            private static string CreateContent(string prefixValue)
+            {
+                return RandomPrefix.Replace("#REPLACE#", $"a{prefixValue}");
+            }
+        }
+    }
+}

--- a/source/XmlConversion/source/XmlConverter/XmlMapper.cs
+++ b/source/XmlConversion/source/XmlConverter/XmlMapper.cs
@@ -40,7 +40,7 @@ namespace Energinet.DataHub.Core.XmlConversion.XmlConverter
         {
             if (rootElement == null) throw new ArgumentNullException(nameof(rootElement));
 
-            XNamespace ns = rootElement.Attributes().FirstOrDefault(attr => attr.Name.LocalName == "cim")?.Value ?? throw new ArgumentException("Found no namespace for XML Document");
+            var ns = rootElement.Name.Namespace;
 
             var headerData = MapHeaderData(rootElement, ns);
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/green-energy-hub) before we can accept your contribution. --->

## Description

If a xml document is parsed that have a different xml-namespace prefix then cim, an exception is thrown. We can't predict what namespace prefix we are to receive in the future. This PR replace the existing logic for locating the prefix, and defaults to the one located at the root element.

## References

The work is based on this incident:
https://app.zenhub.com/workspaces/incident-board-61f28baaf0a6720011a32def/issues/energinet-datahub/green-energy-hub/267
