### PR TITLE
Add backend service principal object id

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 2.2.0
+
+- Added backend service principal object id to `AzureB2CSettings`.
+
 ## Version 2.1.1
 
 - Bumped patch version as pipeline file was updated.

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Configuration/IntegrationTestConfigurationTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Configuration/IntegrationTestConfigurationTests.cs
@@ -37,6 +37,7 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Config
             actualValue.ServicePrincipalId.Should().NotBeNullOrEmpty();
             actualValue.ServicePrincipalSecret.Should().NotBeNullOrEmpty();
             actualValue.BackendAppId.Should().NotBeNullOrEmpty();
+            actualValue.BackendServicePrincipalObjectId.Should().NotBeNullOrEmpty();
         }
 
         [Fact]

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/AzureB2CSettings.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/AzureB2CSettings.cs
@@ -30,5 +30,8 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration
 
         public string BackendAppId { get; internal set; }
             = string.Empty;
+
+        public string BackendServicePrincipalObjectId { get; internal set; }
+            = string.Empty;
     }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/IntegrationTestConfiguration.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/IntegrationTestConfiguration.cs
@@ -103,6 +103,7 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration
                 ServicePrincipalId = configuration.GetValue("AZURE-B2C-SPN-ID"),
                 ServicePrincipalSecret = configuration.GetValue("AZURE-B2C-SPN-SECRET"),
                 BackendAppId = configuration.GetValue("AZURE-B2C-BACKEND-APP-ID"),
+                BackendServicePrincipalObjectId = configuration.GetValue("AZURE-B2C-BACKEND-SPN-OBJECTID"),
             };
         }
     }

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>2.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.2.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>2.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.2.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

For some calls to Azure AD B2C, the backend service principal object id is needed.