### PR TITLE
Overwrite default sql server connection string

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 2.3.0
+
+- Added feature to override default LocalDB SQL server connection string
+
 ## Version 2.2.1
 
 - Bumped patch version as pipeline file was updated.

--- a/source/TestCommon/documents/testcommon.md
+++ b/source/TestCommon/documents/testcommon.md
@@ -27,3 +27,7 @@ The `Sut` instance is not created until the first time it is accessed.
 ## AutoFixture.Extensions
 
 This namespace contains the extension method `ForConstructorOn<TTypeToConstruct>` that can be used to specify parameter values when constructing a type using `AutoFixture`.
+
+## LocalDB SQL Server
+
+It is possible to replace the default connection string to LocalDB by setting an environment variable. If a variable is present with the name `TestCommonConnectionString`, then it's used for connecting to SQL Server. If the value is not a valid SQL Server connection string, then an `System.ArgumentException` is thrown.

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Database/SqlServerConnectionStringProviderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Database/SqlServerConnectionStringProviderTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Energinet.DataHub.Core.FunctionApp.TestCommon.Database;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Database
+{
+    public class SqlServerConnectionStringProviderTests
+    {
+        private const string ValidConnectionString =
+            "Data Source=myServerAddress;Database=myDataBase;Trusted_Connection=True;";
+
+        private const string DatabasePrefix = "MyPrefix";
+        private readonly string _databaseName = Guid.NewGuid().ToString("N");
+
+        [Fact]
+        public void When_EnvironmentVariableIsNotPresent_Then_LocalDb_IsSelected()
+        {
+            var runtime = new FlexibleRuntimeEnvironment(new Dictionary<string, string?>());
+            var sut = new SqlServerConnectionStringProvider(runtime);
+
+            var result = sut.BuildConnectionStringForDatabaseWithPrefix(DatabasePrefix);
+
+            var builder = new SqlConnectionStringBuilder(result);
+
+            builder.DataSource.Should().StartWith("(LocalDB)");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void When_EnvironmentVariableIsPresent_With_Empty_string_Then_LocalDB_Is_Selected(string? environmentValue)
+        {
+            var runtime = new FlexibleRuntimeEnvironment(CreateEnvironmentDictionary(environmentValue));
+            var sut = new SqlServerConnectionStringProvider(runtime);
+
+            var result = sut.BuildConnectionStringForDatabaseWithPrefix(DatabasePrefix);
+
+            var builder = new SqlConnectionStringBuilder(result);
+
+            builder.DataSource.Should().StartWith("(LocalDB)");
+        }
+
+        [Fact]
+        public void When_EnvironmentVariableIsPresent_With_Value_Then_It_is_Selected()
+        {
+            var runtime = new FlexibleRuntimeEnvironment(CreateEnvironmentDictionary(ValidConnectionString));
+            var sut = new SqlServerConnectionStringProvider(runtime);
+
+            var result = sut.BuildConnectionStringForDatabaseWithPrefix(DatabasePrefix);
+
+            var builder = new SqlConnectionStringBuilder(result);
+
+            builder.DataSource.Should().StartWith("myServerAddress");
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRuntimes))]
+        public void When_ConnectionString_Is_Created_Then_Initial_Catalog_Starts_With_Prefix(RuntimeEnvironment runtime)
+        {
+            var sut = new SqlServerConnectionStringProvider(runtime);
+
+            var result = sut.BuildConnectionStringForDatabaseWithPrefix(DatabasePrefix);
+
+            var builder = new SqlConnectionStringBuilder(result);
+
+            builder.InitialCatalog.Should().StartWith(DatabasePrefix);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRuntimes))]
+        public void When_ConnectionString_Is_Created_With_DatabaseName_Then_Initial_Catalog_Is_DatabaseName(RuntimeEnvironment runtime)
+        {
+            var sut = new SqlServerConnectionStringProvider(runtime);
+
+            var result = sut.BuildConnectionStringForDatabaseName(_databaseName);
+            var builder = new SqlConnectionStringBuilder(result);
+
+            builder.InitialCatalog.Should().Be(_databaseName);
+        }
+
+        public static IEnumerable<object[]> GetRuntimes()
+        {
+            yield return new object[] { new FlexibleRuntimeEnvironment(new Dictionary<string, string?>()) }; // no environment variable set
+            yield return new object[] { new FlexibleRuntimeEnvironment(CreateEnvironmentDictionary(string.Empty)) }; // variable set with no value
+            yield return new object[] { new FlexibleRuntimeEnvironment(CreateEnvironmentDictionary(null)) }; // variable set with null value
+            yield return new object[] { new FlexibleRuntimeEnvironment(CreateEnvironmentDictionary(ValidConnectionString)) }; // environment with valid connection string override
+        }
+
+        private static Dictionary<string, string?> CreateEnvironmentDictionary(string? environmentValue)
+        {
+            var dictionary = new Dictionary<string, string?>
+                { { nameof(FlexibleRuntimeEnvironment.TestCommonConnectionString), environmentValue } };
+            return dictionary;
+        }
+
+        private class FlexibleRuntimeEnvironment : RuntimeEnvironment
+        {
+            private readonly Dictionary<string, string?> _environment;
+
+            public FlexibleRuntimeEnvironment(Dictionary<string, string?> environment)
+            {
+                _environment = environment;
+            }
+
+            protected override string? GetEnvironmentVariable(string variableName)
+                => _environment.GetValueOrDefault(variableName);
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Database/SqlServerConnectionStringProviderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Database/SqlServerConnectionStringProviderTests.cs
@@ -95,6 +95,15 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Databa
             builder.InitialCatalog.Should().Be(_databaseName);
         }
 
+        [Fact]
+        public void When_Invalid_ConnectionString_Is_Set_In_Environment_Variable_Then_An_ArgumentException_Is_Thrown()
+        {
+            var runtime = new FlexibleRuntimeEnvironment(CreateEnvironmentDictionary(Guid.Empty.ToString("N")));
+            var sut = new SqlServerConnectionStringProvider(runtime);
+
+            Assert.Throws<ArgumentException>(() => sut.BuildConnectionStringForDatabaseWithPrefix(DatabasePrefix));
+        }
+
         public static IEnumerable<object[]> GetRuntimes()
         {
             yield return new object[] { new FlexibleRuntimeEnvironment(new Dictionary<string, string?>()) }; // no environment variable set

--- a/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerConnectionStringProvider.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerConnectionStringProvider.cs
@@ -51,8 +51,7 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
 
         private static string BuildConnectionStringForLocalDb(string databaseName)
         {
-            // If Connection Timeout=3 is not set, tests that connect to a database that don't exists will take about 10 sec.
-            return $"Data Source=(LocalDB)\\MSSQLLocalDB;Integrated Security=true;Database={databaseName};Connection Timeout=3";
+            return $"Data Source=(LocalDB)\\MSSQLLocalDB;Integrated Security=true;Database={databaseName};";
         }
 
         private static string? BuildConnectionStringFromEnvironmentVariable(RuntimeEnvironment environment, string databaseName)

--- a/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerConnectionStringProvider.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerConnectionStringProvider.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Microsoft.Data.SqlClient;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
+{
+    public class SqlServerConnectionStringProvider
+    {
+        private readonly RuntimeEnvironment _environment;
+
+        public SqlServerConnectionStringProvider(RuntimeEnvironment environment)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// We create a unique database name to ensure tests using this fixture has their own database.
+        /// </summary>
+        public string BuildConnectionStringForDatabaseWithPrefix(string prefixForDatabaseName)
+        {
+            var databaseName = $"{prefixForDatabaseName}Database_{Guid.NewGuid()}";
+
+            return BuildConnectionStringForDatabaseName(databaseName);
+        }
+
+        /// <summary>
+        /// Build a connection string for a database name. First an environment variable is considered.
+        /// If not found, it will fallback to use localDb
+        /// </summary>
+        /// <param name="databaseName">Name of database</param>
+        /// <returns>Connection string to a database</returns>
+        public string BuildConnectionStringForDatabaseName(string databaseName)
+        {
+            return
+                BuildConnectionStringFromEnvironmentVariable(_environment, databaseName) ??
+                BuildConnectionStringForLocalDb(databaseName);
+        }
+
+        private static string BuildConnectionStringForLocalDb(string databaseName)
+        {
+            // If Connection Timeout=3 is not set, tests that connect to a database that don't exists will take about 10 sec.
+            return $"Data Source=(LocalDB)\\MSSQLLocalDB;Integrated Security=true;Database={databaseName};Connection Timeout=3";
+        }
+
+        private static string? BuildConnectionStringFromEnvironmentVariable(RuntimeEnvironment environment, string databaseName)
+        {
+            var env = environment.TestCommonConnectionString;
+            if (string.IsNullOrEmpty(env)) return null;
+
+            var connectionStringBuilder = new SqlConnectionStringBuilder(env) { InitialCatalog = databaseName };
+
+            return connectionStringBuilder.ConnectionString;
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerConnectionStringProvider.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerConnectionStringProvider.cs
@@ -37,8 +37,8 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Database
         }
 
         /// <summary>
-        /// Build a connection string for a database name. First an environment variable is considered.
-        /// If not found, it will fallback to use localDb
+        /// Build a connection string for a database name. Uses <see cref="RuntimeEnvironment.TestCommonConnectionString"/>.
+        /// If null or empty, it will fallback to use localDb
         /// </summary>
         /// <param name="databaseName">Name of database</param>
         /// <returns>Connection string to a database</returns>

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>2.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.3.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/RuntimeEnvironment.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/RuntimeEnvironment.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon
+{
+    public class RuntimeEnvironment
+    {
+        public static RuntimeEnvironment Default => new();
+
+        /// <summary>
+        /// Represent a connection string to overwrite default behaviour of using LocalDB
+        /// </summary>
+        public virtual string? TestCommonConnectionString => GetEnvironmentVariable(nameof(TestCommonConnectionString));
+
+        /// <summary>
+        /// Get value from host environment
+        /// </summary>
+        /// <param name="variableName">name of environment variable</param>
+        /// <returns>Value of environment variable</returns>
+        protected virtual string? GetEnvironmentVariable(string variableName)
+            => Environment.GetEnvironmentVariable(variableName);
+    }
+}

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>2.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.3.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/green-energy-hub) before we can accept your contribution. --->

## Description

Adds an option to override the default connection string. This is done by setting an environment variable.
