### PR TITLE
Fix: Change schema validation error code to `B2B-005` instead of `BadArgument`

### DIFF
--- a/source/SchemaValidation/documents/release-notes/release-notes.md
+++ b/source/SchemaValidation/documents/release-notes/release-notes.md
@@ -1,10 +1,10 @@
 # Schema Validation Release notes
 
-## Version 1.1.11
+## Version 1.0.11
 
 - Changed the `code` returned on schema validation error from `BadArgument` to `B2B-005`
 
-## Version 1.1.10
+## Version 1.0.10
 
 - Bumped patch version as pipeline file was updated.
 

--- a/source/SchemaValidation/documents/release-notes/release-notes.md
+++ b/source/SchemaValidation/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Schema Validation Release notes
 
+## Version 1.1.11
+
+- Changed the `code` returned on schema validation error from `BadArgument` to `B2B-005`
+
 ## Version 1.1.10
 
 - Bumped patch version as pipeline file was updated.

--- a/source/SchemaValidation/source/SchemaValidation.Tests/SchemaValidatingReaderErrorExtensionsTests.cs
+++ b/source/SchemaValidation/source/SchemaValidation.Tests/SchemaValidatingReaderErrorExtensionsTests.cs
@@ -40,7 +40,7 @@ namespace Energinet.DataHub.Core.SchemaValidation.Tests
             var actual = target.CreateErrorResponse();
 
             // Assert
-            Assert.Equal("BadArgument", actual.Error.Code);
+            Assert.Equal("B2B-005", actual.Error.Code);
             Assert.Equal("The specified input does not pass schema validation.", actual.Error.Message);
 
             var details = actual.Error.Details!;
@@ -103,7 +103,7 @@ namespace Energinet.DataHub.Core.SchemaValidation.Tests
             await errorResponse.WriteAsXmlAsync(destination);
 
             // Assert
-            const string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<Error>\r\n  <Code>BadArgument</Code>\r\n  <Message>The specified input does not pass schema validation.</Message>\r\n  <Details>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The 'wrong' element is not declared.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>2</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n  </Details>\r\n</Error>";
+            const string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<Error>\r\n  <Code>B2B-005</Code>\r\n  <Message>The specified input does not pass schema validation.</Message>\r\n  <Details>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The 'wrong' element is not declared.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>2</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n  </Details>\r\n</Error>";
 
             destination.Position = 0;
 
@@ -128,7 +128,7 @@ namespace Energinet.DataHub.Core.SchemaValidation.Tests
             await errorResponse.WriteAsXmlAsync(destination);
 
             // Assert
-            const string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<Error>\r\n  <Code>BadArgument</Code>\r\n  <Message>The specified input does not pass schema validation.</Message>\r\n  <Details>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The required attribute 'genre' is missing.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>50</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The required attribute 'publicationdate' is missing.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>50</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The required attribute 'ISBN' is missing.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>50</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The element 'book' in namespace 'http://www.contoso.com/books' has incomplete content. List of possible elements expected: 'title' in namespace 'http://www.contoso.com/books'.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>50</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n  </Details>\r\n</Error>";
+            const string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<Error>\r\n  <Code>B2B-005</Code>\r\n  <Message>The specified input does not pass schema validation.</Message>\r\n  <Details>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The required attribute 'genre' is missing.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>50</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The required attribute 'publicationdate' is missing.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>50</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The required attribute 'ISBN' is missing.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>50</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n    <Error>\r\n      <Code>SchemaValidationError</Code>\r\n      <Message>The element 'book' in namespace 'http://www.contoso.com/books' has incomplete content. List of possible elements expected: 'title' in namespace 'http://www.contoso.com/books'.</Message>\r\n      <InnerError>\r\n        <LineNumber>1</LineNumber>\r\n        <LinePosition>50</LinePosition>\r\n      </InnerError>\r\n    </Error>\r\n  </Details>\r\n</Error>";
 
             destination.Position = 0;
 

--- a/source/SchemaValidation/source/SchemaValidation/Errors/Error.cs
+++ b/source/SchemaValidation/source/SchemaValidation/Errors/Error.cs
@@ -20,7 +20,7 @@ namespace Energinet.DataHub.Core.SchemaValidation.Errors
 {
     public readonly struct Error
     {
-        private const string ValidationCode = "BadArgument";
+        private const string ValidationCode = "B2B-005";
         private const string ValidationMessage = "The specified input does not pass schema validation.";
         private const string ValidationDetailsCode = "SchemaValidationError";
 

--- a/source/SchemaValidation/source/SchemaValidation/SchemaValidation.csproj
+++ b/source/SchemaValidation/source/SchemaValidation/SchemaValidation.csproj
@@ -29,7 +29,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.SchemaValidation</PackageId>
-    <PackageVersion>1.0.10$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.0.11$(VersionSuffix)</PackageVersion>
     <Title>Schema Validation Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/green-energy-hub) before we can accept your contribution. --->

## Description

According to the business (Christian, SME),
the `code` to be returned on schema validation error is `B2B-005`, not `BadArgument` which is currently used.

This PR changes the code to `B2B-005`.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

https://github.com/Energinet-DataHub/geh-charges/issues/1316
