### PR TITLE
Test that CI checks nuget.org for already existing version number

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -3,7 +3,6 @@
 ## Version 3.0.0
 
 - Upgrade solution projects from .NET 5 to .NET 6
-- remove before merging to main
 
 ## Version 2.4.4
 

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -3,6 +3,7 @@
 ## Version 3.0.0
 
 - Upgrade solution projects from .NET 5 to .NET 6
+- remove before merging to main
 
 ## Version 2.4.4
 

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>2.4.4$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>2.4.4$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -38,7 +38,7 @@ limitations under the License.
     <PackageProjectUrl>https://github.com/Energinet-DataHub</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Energinet-DataHub/geh-core</RepositoryUrl>
     <!-- PackageReleaseNotes:
-      Is shown in Azure DevOps artifacts Release Notes section.
+      Is shown in Azure DevOps artifacts Release Notes section
     -->
     <PackageReleaseNotes>
       [Release Notes](https://github.com/Energinet-DataHub/geh-core/blob/master/source/TestCommon/documents/release-notes/release-notes.md)


### PR DESCRIPTION
## Description

The buildversion 2.4.4 already exists on nuget.org - our CI should fail the build, but it doesn't ??

## References

https://github.com/Energinet-DataHub/the-outlaws/issues/269
