### PR TITLE
Upgrade SchemaValidation from .NET 5 to .NET 6

### DIFF
--- a/source/SchemaValidation/documents/release-notes/release-notes.md
+++ b/source/SchemaValidation/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Schema Validation Release notes
 
+## Version 2.0.0
+
+- Upgrade .NET 5 to .NET 6
+
 ## Version 1.0.13
 
 - Bumped patch version as pipeline file was updated.

--- a/source/SchemaValidation/source/SchemaValidation.Tests/SchemaValidation.Tests.csproj
+++ b/source/SchemaValidation/source/SchemaValidation.Tests/SchemaValidation.Tests.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <ProjectGuid>{99F7C9E7-39FF-4324-94FE-D3071B61DD11}</ProjectGuid>

--- a/source/SchemaValidation/source/SchemaValidation/SchemaValidation.csproj
+++ b/source/SchemaValidation/source/SchemaValidation/SchemaValidation.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <ProjectGuid>{5EAEA68C-424C-40A2-B68B-C5FAEB02BD6B}</ProjectGuid>
@@ -29,7 +29,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.SchemaValidation</PackageId>
-    <PackageVersion>1.0.13$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>Schema Validation Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Upgrade SchemaValidation from .NET 5 to .NET 6

## References

https://github.com/Energinet-DataHub/the-outlaws/issues/269