### PR TITLE
Move to Microsoft.Data.SqlClient

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 4.0.0
+
+- Replaced nuget package [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient) with [Microsoft.Data.SqlClient](https://github.com/dotnet/SqlClient). Going forward, support for new SQL Server features will be implemented in Microsoft.Data.SqlClient. This is a breaking change, if users are referencing the package `System.Data.SqlClient` through `FunctionApp.TestCommon`. 
+
 ## Version 3.1.0
 
 - Added property `LogAnalyticsWorkspaceId` to `IntegrationTestConfiguration` to support use of Log Analytics Workspace.

--- a/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerDatabaseManager.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Database/SqlServerDatabaseManager.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using System;
-using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Polly;
 

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>3.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>
@@ -79,6 +79,7 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Microsoft.Azure.Management.EventHub" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
@@ -93,7 +94,6 @@ limitations under the License.
     </PackageReference>
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageReference Include="Polly" Version="7.2.2" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
     <PackageReference Include="System.Management" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>3.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Going forward, new functionality is added to `Microsoft.Data.SqlClient` and not `System.Data.SqlClient`. This could be a breaking change. Package version is bumped too 4.0.0 with this in mind. 

This will break existing code, if `System.Data.SqlClient` is used in-directly through `FunctionApp.TestCommon`. 
