### PR TITLE
Kerbou/use default dotnetsdk for ci

### DIFF
--- a/.github/workflows/app-common-bundle-publish.yml
+++ b/.github/workflows/app-common-bundle-publish.yml
@@ -65,19 +65,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
         with:
-          DOTNET_VERSION: '6.0.301'
           USE_AZURE_FUNCTIONS_TOOLS: 'true'
           NODE_VERSION: '16'
           AZURITE_VERSION: '3.15.0'
           AZURE_FUNCTIONS_CORE_TOOLS_VERSION: '4.0.3971'
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/App/App.sln'
           CODE_COVERAGE_FLAGS: appcommon
@@ -88,37 +87,37 @@ jobs:
           AZURE_SPN_SECRET: ${{ secrets.AZURE_SPN_SECRET }}
 
       - name: Pack Common project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/App/source/Common/Common.csproj'
 
       - name: Pack Common.Abstractions project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/App/source/Common.Abstractions/Common.Abstractions.csproj'
 
       - name: Pack Common.Security project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/App/source/Common.Security/Common.Security.csproj'
 
       - name: Pack FunctionApp project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/App/source/FunctionApp/FunctionApp.csproj'
 
       - name: Pack WebApp project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/App/source/WebApp/WebApp.csproj'
 
       - name: Pack FunctionApp.SimpleInjector project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj'
 
       - name: Pack WebApp.SimpleInjector project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj'
 
@@ -137,7 +136,7 @@ jobs:
             .github/workflows/app-common-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/.github/workflows/featuremanagement-ci.yml
+++ b/.github/workflows/featuremanagement-ci.yml
@@ -32,10 +32,9 @@ on:
 jobs:
   # Build and test solution, and publish coverage report
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.5.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/FeatureManagement/FeatureManagement.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_AZURE_FUNCTIONS_TOOLS: true
 
   # This job is relevant to allow the status check for 'Publish bundle to NuGet.org' to execute
@@ -47,7 +46,7 @@ jobs:
   # See Github discussion answered in March 2022 for reference: https://github.com/github-community/community/discussions/13690 
   build_and_publish:
     name: Publish bundle to NuGet.org  
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - name: Print something
         run: echo 'This step is needed to enforce the "Publish bundle to NuGet.org" status check'

--- a/.github/workflows/featuremanagement-ci.yml
+++ b/.github/workflows/featuremanagement-ci.yml
@@ -46,7 +46,7 @@ jobs:
   # See Github discussion answered in March 2022 for reference: https://github.com/github-community/community/discussions/13690 
   build_and_publish:
     name: Publish bundle to NuGet.org  
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Print something
         run: echo 'This step is needed to enforce the "Publish bundle to NuGet.org" status check'

--- a/.github/workflows/json-serialization-bundle-publish.yml
+++ b/.github/workflows/json-serialization-bundle-publish.yml
@@ -48,21 +48,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.4.0
-        with:
-          DOTNET_VERSION: '5.0.407'
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/JsonSerialization/JsonSerialization.sln'
           CODE_COVERAGE_FLAGS: jsonserialization
 
       - name: Pack JsonSerialization project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/JsonSerialization/source/JsonSerialization/JsonSerialization.csproj'
 
@@ -75,7 +73,7 @@ jobs:
             .github/workflows/json-serialization-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/.github/workflows/logging-bundle-publish.yml
+++ b/.github/workflows/logging-bundle-publish.yml
@@ -51,21 +51,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.4.0
-        with:
-          DOTNET_VERSION: '5.0.407'
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/Logging/Logging.sln'
           CODE_COVERAGE_FLAGS: logging
 
       - name: Pack RequestResponseMiddleware project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/Logging/source/RequestResponseMiddleware/RequestResponseMiddleware.csproj'
 
@@ -78,7 +76,7 @@ jobs:
             .github/workflows/logging-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/.github/workflows/messaging-bundle-publish.yml
+++ b/.github/workflows/messaging-bundle-publish.yml
@@ -54,36 +54,34 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.4.0
-        with:
-          DOTNET_VERSION: '5.0.407'
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/Messaging/Messaging.sln'
           CODE_COVERAGE_FLAGS: messaging
 
       - name: Pack Messaging project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/Messaging/source/Messaging/Messaging.csproj'
 
       - name: Pack Messaging.Integration.ServiceCollection project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/Messaging/source/Messaging.Integration.ServiceCollection/Messaging.Integration.ServiceCollection.csproj'
 
       - name: Pack Messaging.Protobuf project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/Messaging/source/Messaging.Protobuf/Messaging.Protobuf.csproj'
 
       - name: Pack Messaging.Protobuf.Integration.ServiceCollection project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/Messaging/source/Messaging.Protobuf.Integration.ServiceCollection/Messaging.Protobuf.Integration.ServiceCollection.csproj'
 
@@ -99,7 +97,7 @@ jobs:
             .github/workflows/messaging-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/.github/workflows/schemas-bundle-publish.yml
+++ b/.github/workflows/schemas-bundle-publish.yml
@@ -51,21 +51,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.5.0
-        with:
-          DOTNET_VERSION: '5.0.407'
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/Schemas/Schemas.sln'
           USE_CODE_COVERAGE: 'false'
 
       - name: Pack Schemas project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/Schemas/source/Schemas/Schemas.csproj'
 
@@ -78,7 +76,7 @@ jobs:
             .github/workflows/schemas-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/.github/workflows/schemavalidation-bundle-publish.yml
+++ b/.github/workflows/schemavalidation-bundle-publish.yml
@@ -51,21 +51,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.5.0
-        with:
-          DOTNET_VERSION: '5.0.407'
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
       
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/SchemaValidation/SchemaValidation.sln'
           CODE_COVERAGE_FLAGS: schemavalidation
 
       - name: Pack SchemaValidation project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with: 
           PROJECT_PATH: './source/SchemaValidation/source/SchemaValidation/SchemaValidation.csproj'
       
@@ -78,7 +76,7 @@ jobs:
             .github/workflows/schemavalidation-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -60,19 +60,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
         with:
-          DOTNET_VERSION: '5.0.407'
           USE_AZURE_FUNCTIONS_TOOLS: 'true'
           NODE_VERSION: '16'
           AZURITE_VERSION: '3.15.0'
           AZURE_FUNCTIONS_CORE_TOOLS_VERSION: '4.0.3971'
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/TestCommon/TestCommon.sln'
           CODE_COVERAGE_FLAGS: testcommon
@@ -83,12 +82,12 @@ jobs:
           AZURE_SPN_SECRET: ${{ secrets.AZURE_SPN_SECRET }}
 
       - name: Pack TestCommon project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/TestCommon/source/TestCommon/TestCommon.csproj'
 
       - name: Pack FunctionApp.TestCommon project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj'
 
@@ -102,7 +101,7 @@ jobs:
             .github/workflows/testcommon-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.4.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # App Release notes
 
+## Version 4.0.3
+
+- Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
+
 ## Version 4.0.2
 
 - docs were added for IntegrationEventMetadataMiddleware

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -1,6 +1,6 @@
 # App Release notes
 
-## Version 4.0.3
+## Version 4.1.0
 
 - Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
 

--- a/source/App/source/Common.Abstractions/Common.Abstractions.csproj
+++ b/source/App/source/Common.Abstractions/Common.Abstractions.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Abstractions</PackageId>
-    <PackageVersion>4.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Abstractions/Common.Abstractions.csproj
+++ b/source/App/source/Common.Abstractions/Common.Abstractions.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Abstractions</PackageId>
-    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Security/Common.Security.csproj
+++ b/source/App/source/Common.Security/Common.Security.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Security</PackageId>
-    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Security Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Security/Common.Security.csproj
+++ b/source/App/source/Common.Security/Common.Security.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Security</PackageId>
-    <PackageVersion>4.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Security Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common/Common.csproj
+++ b/source/App/source/Common/Common.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common</PackageId>
-    <PackageVersion>4.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common/Common.csproj
+++ b/source/App/source/Common/Common.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common</PackageId>
-    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
+++ b/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp.SimpleInjector</PackageId>
-    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
+++ b/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp.SimpleInjector</PackageId>
-    <PackageVersion>4.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp</PackageId>
-    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp</PackageId>
-    <PackageVersion>4.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
     <Title>Azure Function App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
+++ b/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp.SimpleInjector</PackageId>
-    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure WebApp Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
+++ b/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp.SimpleInjector</PackageId>
-    <PackageVersion>4.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
     <Title>Azure WebApp Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp/WebApp.csproj
+++ b/source/App/source/WebApp/WebApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp</PackageId>
-    <PackageVersion>4.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
     <Title>Azure Web App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp/WebApp.csproj
+++ b/source/App/source/WebApp/WebApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp</PackageId>
-    <PackageVersion>4.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Web App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/JsonSerialization/documents/release-notes.md
+++ b/source/JsonSerialization/documents/release-notes.md
@@ -1,5 +1,9 @@
 # JsonSerialization Release Notes
 
+## Version 2.1.0
+
+- Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
+
 ## Version 2.0.0
 
 - Upgrade project to build .NET 6 instead of .NET Standard 2.1

--- a/source/JsonSerialization/source/JsonSerialization/JsonSerialization.csproj
+++ b/source/JsonSerialization/source/JsonSerialization/JsonSerialization.csproj
@@ -29,7 +29,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.JsonSerialization</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>JsonSerialization library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Logging/documents/release-notes/release-notes.md
+++ b/source/Logging/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Logging Middleware for Request and Response Release notes
 
+## Version 2.2.0
+
+- Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
+
 ## Version 2.1.0
 
 - Upgrade Azure.Storage.Blobs to 12.13.0

--- a/source/Logging/source/RequestResponseMiddleware/RequestResponseMiddleware.csproj
+++ b/source/Logging/source/RequestResponseMiddleware/RequestResponseMiddleware.csproj
@@ -26,7 +26,7 @@ limitations under the License.
 
 	<PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Logging</PackageId>
-    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.2.0$(VersionSuffix)</PackageVersion>
     <Title>Logging Middleware For Requests and Responses</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Messaging/documents/release-notes/release-notes.md
+++ b/source/Messaging/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Messaging Release notes
 
+## Version 2.1.0
+
+- Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
+
 ## Version 2.0.0
 
 - Upgrade from .NET 5 to .NET 6

--- a/source/Messaging/source/Messaging.Integration.ServiceCollection/Messaging.Integration.ServiceCollection.csproj
+++ b/source/Messaging/source/Messaging.Integration.ServiceCollection/Messaging.Integration.ServiceCollection.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Messaging.Integration.ServiceCollection</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>Messaging Integration library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Messaging/source/Messaging.Protobuf.Integration.ServiceCollection/Messaging.Protobuf.Integration.ServiceCollection.csproj
+++ b/source/Messaging/source/Messaging.Protobuf.Integration.ServiceCollection/Messaging.Protobuf.Integration.ServiceCollection.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>Messaging Protobuf Integration library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Messaging/source/Messaging.Protobuf/Messaging.Protobuf.csproj
+++ b/source/Messaging/source/Messaging.Protobuf/Messaging.Protobuf.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Messaging.Protobuf</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>Messaging Protobuf library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Messaging/source/Messaging/Messaging.csproj
+++ b/source/Messaging/source/Messaging/Messaging.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Messaging</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>Messaging library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/SchemaValidation/documents/release-notes/release-notes.md
+++ b/source/SchemaValidation/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Schema Validation Release notes
 
+## Version 2.1.0
+
+- Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
+
 ## Version 2.0.0
 
 - Upgrade .NET 5 to .NET 6

--- a/source/SchemaValidation/source/SchemaValidation/SchemaValidation.csproj
+++ b/source/SchemaValidation/source/SchemaValidation/SchemaValidation.csproj
@@ -29,7 +29,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.SchemaValidation</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>Schema Validation Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Schemas/documents/release-notes/release-notes.md
+++ b/source/Schemas/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Schemas Release notes
 
+## Version 2.1.0
+
+- Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
+
 ## Version 2.0.1
 
 - Updated RSM-* schemas.

--- a/source/Schemas/source/Schemas/Schemas.csproj
+++ b/source/Schemas/source/Schemas/Schemas.csproj
@@ -29,7 +29,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Schemas</PackageId>
-    <PackageVersion>2.0.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>Schema Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 3.2.0
+
+- Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
+
 ## Version 3.1.0
 
 - Added property `LogAnalyticsWorkspaceId` to `IntegrationTestConfiguration` to support use of Log Analytics Workspace.

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>3.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.2.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>3.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.2.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/XmlConversion/documents/release-notes/release-notes.md
+++ b/source/XmlConversion/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # XML Converter Release notes
 
+## Version 2.1.0
+
+- Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow
+
 ## Version 2.0.0
 
 - Upgrade from .NET 5 to .NET 6

--- a/source/XmlConversion/source/XmlConverter.Abstractions/XmlConverter.Abstractions.csproj
+++ b/source/XmlConversion/source/XmlConverter.Abstractions/XmlConverter.Abstractions.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.XmlConversion.XmlConverter.Abstractions</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>XmlConverter Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/XmlConversion/source/XmlConverter.SimpleInjector/XmlConverter.SimpleInjector.csproj
+++ b/source/XmlConversion/source/XmlConverter.SimpleInjector/XmlConverter.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.XmlConversion.XmlConverter.SimpleInjector</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>XmlConverter SimpleInjector Extension Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/XmlConversion/source/XmlConverter/XmlConverter.csproj
+++ b/source/XmlConversion/source/XmlConverter/XmlConverter.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.XmlConversion.XmlConverter</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.1.0$(VersionSuffix)</PackageVersion>
     <Title>XmlConverter Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
Speed up CI execution time by using default .NET Core SDK version pre-installed on hosted Github Runner

Reference: https://github.com/Energinet-DataHub/the-outlaws/issues/360