### PR TITLE
Update Test common and App Common to use new version of actions in pipeline

### DIFF
--- a/.github/workflows/app-common-bundle-publish.yml
+++ b/.github/workflows/app-common-bundle-publish.yml
@@ -51,6 +51,10 @@ env:
   # Overrides settings in 'functionhost.settings.json'
   FunctionAppHostPath: '${{ github.workspace }}\node_modules\azure-functions-core-tools\bin\func.dll'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
 
   build_and_publish:
@@ -58,17 +62,14 @@ jobs:
     runs-on: windows-2022
     name: Publish bundle to NuGet.org
 
-    permissions:
-      contents: read
-
     environment: CI
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.8.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.8.0
         with:
           USE_AZURE_FUNCTIONS_TOOLS: 'true'
           NODE_VERSION: '16'
@@ -76,7 +77,7 @@ jobs:
           AZURE_FUNCTIONS_CORE_TOOLS_VERSION: '4.0.3971'
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.8.0
         with:
           SOLUTION_FILE_PATH: './source/App/App.sln'
           CODE_COVERAGE_FLAGS: appcommon
@@ -84,40 +85,39 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID }}
-          AZURE_SPN_SECRET: ${{ secrets.AZURE_SPN_SECRET }}
 
       - name: Pack Common project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/App/source/Common/Common.csproj'
 
       - name: Pack Common.Abstractions project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/App/source/Common.Abstractions/Common.Abstractions.csproj'
 
       - name: Pack Common.Security project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/App/source/Common.Security/Common.Security.csproj'
 
       - name: Pack FunctionApp project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/App/source/FunctionApp/FunctionApp.csproj'
 
       - name: Pack WebApp project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/App/source/WebApp/WebApp.csproj'
 
       - name: Pack FunctionApp.SimpleInjector project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj'
 
       - name: Pack WebApp.SimpleInjector project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj'
 
@@ -136,7 +136,7 @@ jobs:
             .github/workflows/app-common-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.8.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/.github/workflows/app-common-bundle-publish.yml
+++ b/.github/workflows/app-common-bundle-publish.yml
@@ -84,7 +84,7 @@ jobs:
           AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID }}
+          AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID_OIDC }}
 
       - name: Pack Common project
         uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0

--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -79,7 +79,7 @@ jobs:
           AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID }}
+          AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID_OIDC }}
 
       - name: Pack TestCommon project
         uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0

--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -46,6 +46,10 @@ env:
   # Overrides settings in 'functionhost.settings.json'
   FunctionAppHostPath: '${{ github.workspace }}\node_modules\azure-functions-core-tools\bin\func.dll'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
 
   build_and_publish:
@@ -53,17 +57,14 @@ jobs:
     runs-on: windows-2022
     name: Publish bundle to NuGet.org
 
-    permissions:
-      contents: read
-
     environment: CI
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.8.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.8.0
         with:
           USE_AZURE_FUNCTIONS_TOOLS: 'true'
           NODE_VERSION: '16'
@@ -71,7 +72,7 @@ jobs:
           AZURE_FUNCTIONS_CORE_TOOLS_VERSION: '4.0.3971'
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.8.0
         with:
           SOLUTION_FILE_PATH: './source/TestCommon/TestCommon.sln'
           CODE_COVERAGE_FLAGS: testcommon
@@ -79,15 +80,14 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID }}
-          AZURE_SPN_SECRET: ${{ secrets.AZURE_SPN_SECRET }}
 
       - name: Pack TestCommon project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/TestCommon/source/TestCommon/TestCommon.csproj'
 
       - name: Pack FunctionApp.TestCommon project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.8.0
         with:
           PROJECT_PATH: './source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj'
 
@@ -101,7 +101,7 @@ jobs:
             .github/workflows/testcommon-bundle-publish.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.8.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -1,6 +1,6 @@
 # App Release notes
 
-## Version 4.2.0
+## Version 4.1.1
 
 - Bump version as part of pipeline change
 

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # App Release notes
 
+## Version 4.2.0
+
+- Bump version as part of pipeline change
+
 ## Version 4.1.0
 
 - Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow

--- a/source/App/source/Common.Abstractions/Common.Abstractions.csproj
+++ b/source/App/source/Common.Abstractions/Common.Abstractions.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Abstractions</PackageId>
-    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.1$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Abstractions/Common.Abstractions.csproj
+++ b/source/App/source/Common.Abstractions/Common.Abstractions.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Abstractions</PackageId>
-    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Security/Common.Security.csproj
+++ b/source/App/source/Common.Security/Common.Security.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Security</PackageId>
-    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Security Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Security/Common.Security.csproj
+++ b/source/App/source/Common.Security/Common.Security.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Security</PackageId>
-    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.1$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Security Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common/Common.csproj
+++ b/source/App/source/Common/Common.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common</PackageId>
-    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.1$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common/Common.csproj
+++ b/source/App/source/Common/Common.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common</PackageId>
-    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
+++ b/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp.SimpleInjector</PackageId>
-    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.1$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
+++ b/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp.SimpleInjector</PackageId>
-    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp</PackageId>
-    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.1$(VersionSuffix)</PackageVersion>
     <Title>Azure Function App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp</PackageId>
-    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
+++ b/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp.SimpleInjector</PackageId>
-    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
     <Title>Azure WebApp Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
+++ b/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp.SimpleInjector</PackageId>
-    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.1$(VersionSuffix)</PackageVersion>
     <Title>Azure WebApp Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp/WebApp.csproj
+++ b/source/App/source/WebApp/WebApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp</PackageId>
-    <PackageVersion>4.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Web App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp/WebApp.csproj
+++ b/source/App/source/WebApp/WebApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp</PackageId>
-    <PackageVersion>4.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.1$(VersionSuffix)</PackageVersion>
     <Title>Azure Web App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 3.3.0
+
+- Bump version as part of pipeline change
+
 ## Version 3.2.0
 
 - Use default .NET Core SDK version pre-installed on Github Runner when running CI workflow

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,6 +1,6 @@
 # TestCommon Release notes
 
-## Version 3.3.0
+## Version 3.2.1
 
 - Bump version as part of pipeline change
 

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>3.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.3.0$(VersionSuffix)
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>3.3.0$(VersionSuffix)
+    <PackageVersion>3.3.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>3.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.2.1$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>3.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.3.0$(VersionSuffix)
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>3.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.2.1$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>3.3.0$(VersionSuffix)
+    <PackageVersion>3.3.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
The two pipelines calls the action `dotnet-solution-build-and-test`. In version 7.7.0 this action logged into Azure using a SPN secret. In version 7.8.0 it authentication is based on OIDC