### PR TITLE
App: Rename correlation id header

### DIFF
--- a/source/App/documents/correlationIdMiddleware.md
+++ b/source/App/documents/correlationIdMiddleware.md
@@ -3,7 +3,7 @@
 Contains a middleware implementation of exposing the `CorrelationId` from the `FunctionContext` from either a `HttpTrigger` or `ServiceBusTrigger`.
 
 ### HttpTrigger
-The CorrelationId is parsed from a http-header named `Correlation-ID`
+The CorrelationId is parsed from a http-header named `CorrelationId`
 
 ### ServiceBusTrigger
 The CorrelationId is parsed from a user property named `OperationCorrelationId`

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # App Release notes
 
+## Version 6.0.0
+
+- Change `CorrelationIdMiddleware` to use `CorrelationId` header instead of `Correlation-ID` header.
+
 ## Version 5.0.2
 
 - Bump version as part of pipeline change

--- a/source/App/source/Common.Abstractions/Common.Abstractions.csproj
+++ b/source/App/source/Common.Abstractions/Common.Abstractions.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Abstractions</PackageId>
-    <PackageVersion>5.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Security/Common.Security.csproj
+++ b/source/App/source/Common.Security/Common.Security.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Security</PackageId>
-    <PackageVersion>5.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Security Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common/Common.csproj
+++ b/source/App/source/Common/Common.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common</PackageId>
-    <PackageVersion>5.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
+++ b/source/App/source/FunctionApp.SimpleInjector/FunctionApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp.SimpleInjector</PackageId>
-    <PackageVersion>5.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/source/App/source/FunctionApp.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -232,7 +232,7 @@ namespace Energinet.DataHub.Core.App.FunctionApp.Tests.Middleware
 
             context.BindingContext
                 .Setup(bindingContext => bindingContext.BindingData)
-                .Returns(SetupHeaders("Correlation-ID", operationCorrelationId));
+                .Returns(SetupHeaders("CorrelationId", operationCorrelationId));
 
             // Act
             await target.Invoke(context.FunctionContext, _ => Task.CompletedTask);
@@ -243,10 +243,10 @@ namespace Energinet.DataHub.Core.App.FunctionApp.Tests.Middleware
         }
 
         [Theory]
-        [InlineData("CORRELATION-ID")]
-        [InlineData("correlation-ID")]
-        [InlineData("Correlation-ID")]
-        [InlineData("correlation-id")]
+        [InlineData("CORRELATIONID")]
+        [InlineData("correlationID")]
+        [InlineData("CorrelationID")]
+        [InlineData("correlationid")]
         public async Task Invoke_HttpTriggerWithDifferentCasing_SetsCorrelationId(string headerName)
         {
             // Arrange

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp</PackageId>
-    <PackageVersion>5.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp/Middleware/CorrelationId/CorrelationIdMiddleware.cs
+++ b/source/App/source/FunctionApp/Middleware/CorrelationId/CorrelationIdMiddleware.cs
@@ -88,7 +88,7 @@ namespace Energinet.DataHub.Core.App.FunctionApp.Middleware.CorrelationId
             var normalizedKeyHeaders = headers
                 .ToDictionary(h => h.Key.ToLowerInvariant(), h => h.Value);
 
-            return normalizedKeyHeaders.TryGetValue("correlation-id", out correlationId);
+            return normalizedKeyHeaders.TryGetValue("correlationid", out correlationId);
         }
     }
 }

--- a/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
+++ b/source/App/source/WebApp.SimpleInjector/WebApp.SimpleInjector.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp.SimpleInjector</PackageId>
-    <PackageVersion>5.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>Azure WebApp Dependency Injection Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp/WebApp.csproj
+++ b/source/App/source/WebApp/WebApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp</PackageId>
-    <PackageVersion>5.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Web App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Rename Correlation-ID header to CorrelationId to match the header name used by customers.

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/440