### PR TITLE
Support B2C tests

### DIFF
--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -41,6 +41,7 @@ env:
   PUSH_PACKAGES: ${{ github.event_name != 'pull_request' }}
   # Variables necessary to manage Azure resources for tests (similar to local use of 'integrationtest.local.settings.json')
   AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
+  AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
   # Set value used by 'AzuriteManager'
   AzuriteBlobFolderPath: '${{ github.workspace }}\node_modules\.bin\'
   # Overrides settings in 'functionhost.settings.json'

--- a/source/TestCommon/TestCommon.sln
+++ b/source/TestCommon/TestCommon.sln
@@ -1,10 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31727.386
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32802.462
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documents", "documents", "{3596B88D-1C47-4D10-AFE8-0EE81AD6B968}"
 	ProjectSection(SolutionItems) = preProject
+		documents\b2ctokenretrieval.md = documents\b2ctokenretrieval.md
 		documents\development.md = documents\development.md
 		documents\documentation.md = documents\documentation.md
 		documents\eventhublistenermock.md = documents\eventhublistenermock.md

--- a/source/TestCommon/documents/b2ctokenretrieval.md
+++ b/source/TestCommon/documents/b2ctokenretrieval.md
@@ -1,0 +1,43 @@
+# Azure AD B2C token retrieval
+
+In DataHub we use Azure AD B2C to build a cloud identity directory. Users and client applications are created as entities in this directory. Users can access the UI (frontend) if given access to the frontend application. Client applications can access the API if given access to the backend application.
+
+In the authentication and authorization of users and client applications we use JWT's. As the external interface is http based, any incoming http requests requires an access token. To be able to perform integration or system tests targeting http requests, we therefore need to be able to retrieve an access token similar to a user or client application.
+
+The `B2CAuthorizationConfiguration` makes it easy to retrieve settings we have stored in a key vault, which are required in the process of retrieving and validating access tokens.
+
+The `B2CAppAuthenticationClient` makes it easy, using settings retrieved by `B2CAuthorizationConfiguration`, to retrieve an access token for a client application targeting a backend application.
+
+> For usage, see `B2CFixture` or [Charges](https://github.com/Energinet-DataHub/geh-charges) repository/domain.
+
+## Example
+
+In the following example we will show how we can retrieve an access token that allows the client application (here `endk-tso`) access to the backend application (the DataHub API) in the development environment (here `u001`). This access token must then later be added to http requests from the client application.
+
+To test using the `endk-tso` client application in the `u001` enviroments we first initialize the `B2CAuthorizationConfiguration` like:
+
+```csharp
+var environment = "u001";
+var systemOperator = "endk-tso";
+
+var authorizationConfiguration = new B2CAuthorizationConfiguration(
+    usedForSystemTests: false,
+    environment: environment,
+    new List<string> { systemOperator });
+```
+
+Then, using the retrieved settings, we can initialize the `B2CAppAuthenticationClient` like:
+
+```csharp
+var backendAppAuthenticationClient = new B2CAppAuthenticationClient(
+    authorizationConfiguration.TenantId,
+    authorizationConfiguration.BackendApp,
+    authorizationConfiguration.ClientApps[systemOperator]);
+```
+
+Finally we can use the `B2CAppAuthenticationClient` to retrieve an access token like:
+
+```csharp
+var authenticationResult = await Fixture.BackendAppAuthenticationClient.GetAuthenticationTokenAsync();
+var accessToken = authenticationResult.AccessToken;
+```

--- a/source/TestCommon/documents/functionapp-testcommon.md
+++ b/source/TestCommon/documents/functionapp-testcommon.md
@@ -129,6 +129,8 @@ To support the retrieval of B2C access tokens we have the following classes:
 * `B2CAuthorizationConfiguration` can be used to retrieve B2C relevant settings for the U/T environments.
 * `B2CAppAuthenticationClient` can be used to retrieve an access token for a B2C client application that want to access another B2C application.
 
+For details, see [b2ctokenretrieval.md](b2ctokenretrieval.md).
+
 ### Managers
 
 First of all we have a group of components that we use to *manage* ressources or tools. Each component can manage a certain kind of ressource/tool, and are named as `<ressource/tool-type>Manager`.

--- a/source/TestCommon/documents/functionapp-testcommon.md
+++ b/source/TestCommon/documents/functionapp-testcommon.md
@@ -123,6 +123,12 @@ Connection strings etc. necessary to connect to shared resources, are stored as 
 
 The `IntegrationTestConfiguration` can be used to retrieve these secrets in integration test setup.
 
+### Azure AD B2C token retrieval
+
+To support the retrieval of B2C access tokens we have the following classes:
+* `B2CAuthorizationConfiguration` can be used to retrieve B2C relevant settings for the U/T environments.
+* `B2CAppAuthenticationClient` can be used to retrieve an access token for a B2C client application that want to access another B2C application.
+
 ### Managers
 
 First of all we have a group of components that we use to *manage* ressources or tools. Each component can manage a certain kind of ressource/tool, and are named as `<ressource/tool-type>Manager`.

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 3.3.0
 
-- Implement classes in `Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C` namespace, to support tests using B2C access tokens.
+- Implemented classes in `Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C` namespace, to support tests using B2C access tokens. See [Azure AD B2C token retrieval](..\functionapp-testcommon.md#Azure-AD-B2C-token-retrieval).
 
 ## Version 3.2.2
 

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 3.3.0
+
+- Implement classes in `Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C` namespace, to support tests using B2C access tokens.
+
 ## Version 3.2.2
 
 - Bump version as part of pipeline change

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Fixtures/B2CFixture.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Fixtures/B2CFixture.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Fixtures
+{
+    public class B2CFixture
+    {
+        /// <summary>
+        /// We are actually using this for integration tests and not system tests,
+        /// so we can use any of the allowed environments.
+        /// </summary>
+        public const string Environment = "u001";
+
+        /// <summary>
+        /// We don't require a certain client app, we can use any for which we can
+        /// get a valid access token.
+        /// </summary>
+        public const string SystemOperator = "endk-tso";
+
+        public B2CFixture()
+        {
+            AuthorizationConfiguration = new B2CAuthorizationConfiguration(
+                usedForSystemTests: false,
+                environment: Environment,
+                new List<string> { SystemOperator });
+
+            BackendAppAuthenticationClient = new B2CAppAuthenticationClient(
+                AuthorizationConfiguration.TenantId,
+                AuthorizationConfiguration.BackendApp,
+                AuthorizationConfiguration.ClientApps[SystemOperator]);
+        }
+
+        public B2CAuthorizationConfiguration AuthorizationConfiguration { get; }
+
+        public B2CAppAuthenticationClient BackendAppAuthenticationClient { get; }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Configuration/B2C/B2CAppAuthenticationClientTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Configuration/B2C/B2CAppAuthenticationClientTests.cs
@@ -31,8 +31,9 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Config
         [Fact]
         public async Task BackendAppAuthenticationClient_Should_RetrieveToken()
         {
-            var token = await Fixture.BackendAppAuthenticationClient.GetAuthenticationTokenAsync();
-            token.Should().NotBeNull();
+            var authenticationResult = await Fixture.BackendAppAuthenticationClient.GetAuthenticationTokenAsync();
+            authenticationResult.Should().NotBeNull();
+            authenticationResult.AccessToken.Should().NotBeNullOrWhiteSpace();
         }
     }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Configuration/B2C/B2CAppAuthenticationClientTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Configuration/B2C/B2CAppAuthenticationClientTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Configuration.B2C
+{
+    public class B2CAppAuthenticationClientTests : IClassFixture<B2CFixture>
+    {
+        public B2CAppAuthenticationClientTests(B2CFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        private B2CFixture Fixture { get; }
+
+        [Fact]
+        public async Task BackendAppAuthenticationClient_Should_RetrieveToken()
+        {
+            var token = await Fixture.BackendAppAuthenticationClient.GetAuthenticationTokenAsync();
+            token.Should().NotBeNull();
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Configuration/B2C/B2CAuthorizationConfigurationTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Configuration/B2C/B2CAuthorizationConfigurationTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Configuration.B2C
+{
+    public class B2CAuthorizationConfigurationTests : IClassFixture<B2CFixture>
+    {
+        public B2CAuthorizationConfigurationTests(B2CFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        private B2CFixture Fixture { get; }
+
+        [Fact]
+        public void ClientApps_Should_ContainSingle()
+        {
+            Fixture.AuthorizationConfiguration.ClientApps.Should().ContainSingle();
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/integrationtest.local.settings.sample.json
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/integrationtest.local.settings.sample.json
@@ -1,3 +1,4 @@
 ﻿{
-  "AZURE_KEYVAULT_URL": "<Integration test key vault url>"
+  "AZURE_KEYVAULT_URL": "<Integration test key vault url>",
+  "AZURE_SECRETS_KEYVAULT_URL": "<Key vault with secrets url>"
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/AzureB2CSettings.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/AzureB2CSettings.cs
@@ -15,7 +15,7 @@
 namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration
 {
     /// <summary>
-    /// Settings necessary for managing the Azure AD B2C.
+    /// Settings necessary for managing the Azure AD B2C located in the integration test environment.
     /// </summary>
     public record AzureB2CSettings()
     {

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAppAuthenticationClient.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAppAuthenticationClient.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
+{
+    public class B2CAppAuthenticationClient
+    {
+        public B2CAppAuthenticationClient(
+            string tenantId,
+            B2CAppSettings appSettings,
+            B2CClientAppSettings clientAppSettings)
+        {
+            TenantId = tenantId;
+            AppSettings = appSettings;
+            ClientAppSettings = clientAppSettings;
+
+            ConfidentialClientApp = CreateConfidentialClientApp(TenantId, ClientAppSettings);
+        }
+
+        /// <summary>
+        /// Tenant id.
+        /// </summary>
+        public string TenantId { get; }
+
+        /// <summary>
+        /// The application to which we want an access token.
+        /// </summary>
+        public B2CAppSettings AppSettings { get; }
+
+        /// <summary>
+        /// The client application for which we want an access token.
+        /// </summary>
+        public B2CClientAppSettings ClientAppSettings { get; }
+
+        private IConfidentialClientApplication ConfidentialClientApp { get; }
+
+        public async Task<AuthenticationResult> GetAuthenticationTokenAsync()
+        {
+            var result = await ConfidentialClientApp.AcquireTokenForClient(AppSettings.AppScope)
+                .ExecuteAsync().ConfigureAwait(false);
+
+            return result;
+        }
+
+        private static IConfidentialClientApplication CreateConfidentialClientApp(string tenantId, B2CClientAppSettings clientAppSettings)
+        {
+            var confidentialClientApp = ConfidentialClientApplicationBuilder
+                .Create(clientAppSettings.CredentialSettings.ClientId)
+                .WithClientSecret(clientAppSettings.CredentialSettings.ClientSecret)
+                .WithAuthority(new Uri($"https://login.microsoftonline.com/{tenantId}"))
+                .Build();
+
+            return confidentialClientApp;
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAppAuthenticationClient.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAppAuthenticationClient.cs
@@ -18,6 +18,10 @@ using Microsoft.Identity.Client;
 
 namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
 {
+    /// <summary>
+    /// A component that encapsulates the retrieval of an access token for a
+    /// B2C client application accessing another B2C application.
+    /// </summary>
     public class B2CAppAuthenticationClient
     {
         public B2CAppAuthenticationClient(

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAppSettings.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAppSettings.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
+{
+    /// <summary>
+    /// Id and scope for a B2C application to which we want access by using an access token.
+    /// </summary>
+    public record B2CAppSettings
+    {
+        public B2CAppSettings(string appId)
+        {
+            AppId = appId;
+            AppScope = new[] { $"{AppId}/.default" };
+        }
+
+        /// <summary>
+        /// Id of the application.
+        /// </summary>
+        public string AppId { get; }
+
+        /// <summary>
+        /// The scope for which we must request an access token, to be authorized by the API Management.
+        /// </summary>
+        public IEnumerable<string> AppScope { get; }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAuthorizationConfiguration.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAuthorizationConfiguration.cs
@@ -109,12 +109,21 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
         private IReadOnlyDictionary<string, B2CClientAppSettings> CreateClientApps(IEnumerable<string> clientNames)
         {
             return clientNames
-                .Select(clientName => new B2CClientAppSettings(
-                        clientName,
-                        new B2CClientAppCredentialsSettings(
-                            SecretsConfiguration.GetValue<string>(BuildB2CClientSecretName(Environment, clientName, "client-id")),
-                            SecretsConfiguration.GetValue<string>(BuildB2CClientSecretName(Environment, clientName, "client-secret")))))
+                .Select(clientName => CreateClientAppSettings(clientName))
                 .ToDictionary(o => o.Name, o => o);
+        }
+
+        private B2CClientAppSettings CreateClientAppSettings(string clientName)
+        {
+            return new B2CClientAppSettings
+            {
+                Name = clientName,
+                CredentialSettings = new B2CClientAppCredentialsSettings
+                {
+                    ClientId = SecretsConfiguration.GetValue<string>(BuildB2CClientSecretName(Environment, clientName, "client-id")),
+                    ClientSecret = SecretsConfiguration.GetValue<string>(BuildB2CClientSecretName(Environment, clientName, "client-secret")),
+                },
+            };
         }
 
         /// <summary>

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAuthorizationConfiguration.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAuthorizationConfiguration.cs
@@ -1,0 +1,153 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
+{
+    /// <summary>
+    /// Responsible for extracting secrets for authorization needed for performing tests using B2C access tokens.
+    ///
+    /// On developer machines we use a '*.local.settings.json' to set values.
+    /// On hosted agents we must set these using environment variables.
+    ///
+    /// Developers, and the service principal under which the tests are executed, must have access
+    /// to the Key Vault so secrets can be extracted.
+    /// </summary>
+    public class B2CAuthorizationConfiguration
+    {
+        public B2CAuthorizationConfiguration(
+            bool usedForSystemTests,
+            string environment,
+            IEnumerable<string> clientNames)
+        {
+            var localSettingsJsonFilename = usedForSystemTests
+                ? "systemtest.local.settings.json"
+                : "integrationtest.local.settings.json";
+            var azureSecretsKeyVaultUrlKey = usedForSystemTests
+                ? "AZURE_SYSTEMTESTS_KEYVAULT_URL"
+                : "AZURE_SECRETS_KEYVAULT_URL";
+            RootConfiguration = BuildKeyVaultConfigurationRoot(localSettingsJsonFilename);
+            SecretsConfiguration = BuildSecretsKeyVaultConfiguration(RootConfiguration.GetValue<string>(azureSecretsKeyVaultUrlKey));
+
+            Environment = environment;
+            ClientApps = CreateClientApps(clientNames);
+
+            TenantId = SecretsConfiguration.GetValue<string>(BuildB2CEnvironmentSecretName(Environment, "tenant-id"));
+
+            var backendAppId = SecretsConfiguration.GetValue<string>(BuildB2CEnvironmentSecretName(Environment, "backend-app-id"));
+            BackendApp = new B2CAppSettings(backendAppId);
+
+            var frontendAppId = SecretsConfiguration.GetValue<string>(BuildB2CEnvironmentSecretName(Environment, "frontend-app-id"));
+            FrontendApp = new B2CAppSettings(frontendAppId);
+
+            ApiManagementBaseAddress = SecretsConfiguration.GetValue<Uri>(BuildApiManagementEnvironmentSecretName(Environment, "host-url"));
+            FrontendOpenIdUrl = SecretsConfiguration.GetValue<string>(BuildB2CEnvironmentSecretName(Environment, "frontend-open-id-url"));
+        }
+
+        /// <summary>
+        /// Environment short name with instance indication.
+        /// </summary>
+        public string Environment { get; }
+
+        /// <summary>
+        /// Client apps settings.
+        /// </summary>
+        public IReadOnlyDictionary<string, B2CClientAppSettings> ClientApps { get; }
+
+        /// <summary>
+        /// The B2C tenant id in the configured environment.
+        /// </summary>
+        public string TenantId { get; }
+
+        /// <summary>
+        /// Backend application ID and scope.
+        /// </summary>
+        public B2CAppSettings BackendApp { get; }
+
+        /// <summary>
+        /// Frontend application ID and scope.
+        /// </summary>
+        public B2CAppSettings FrontendApp { get; }
+
+        /// <summary>
+        /// URL of the Open ID configuration for the frontend.
+        /// </summary>
+        public string FrontendOpenIdUrl { get; }
+
+        /// <summary>
+        /// The base address for the API Management in the configured environment.
+        /// </summary>
+        public Uri ApiManagementBaseAddress { get; }
+
+        private IConfigurationRoot RootConfiguration { get; }
+
+        /// <summary>
+        /// Can be used to extract secrets from the Key Vault.
+        /// </summary>
+        private IConfigurationRoot SecretsConfiguration { get; }
+
+        /// <summary>
+        /// Create a dictionary of B2C client apps used for testing, each with its own settings necessary to acquire an access token in a configured environment.
+        /// </summary>
+        /// <param name="clientNames">List of client names or shorthands. For many clients the name is a team name.</param>
+        /// <returns>A dictionary of B2C clients apps used for testing.</returns>
+        private IReadOnlyDictionary<string, B2CClientAppSettings> CreateClientApps(IEnumerable<string> clientNames)
+        {
+            return clientNames
+                .Select(clientName => new B2CClientAppSettings(
+                        clientName,
+                        new B2CClientAppCredentialsSettings(
+                            SecretsConfiguration.GetValue<string>(BuildB2CClientSecretName(Environment, clientName, "client-id")),
+                            SecretsConfiguration.GetValue<string>(BuildB2CClientSecretName(Environment, clientName, "client-secret")))))
+                .ToDictionary(o => o.Name, o => o);
+        }
+
+        /// <summary>
+        /// Load settings from key vault.
+        /// </summary>
+        private static IConfigurationRoot BuildSecretsKeyVaultConfiguration(string keyVaultUrl)
+        {
+            return new ConfigurationBuilder()
+                .AddAuthenticatedAzureKeyVault(keyVaultUrl)
+                .Build();
+        }
+
+        private static IConfigurationRoot BuildKeyVaultConfigurationRoot(string localSettingsJsonFilename)
+        {
+            return new ConfigurationBuilder()
+                .AddJsonFile(localSettingsJsonFilename, optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+        }
+
+        private static string BuildApiManagementEnvironmentSecretName(string environment, string secret)
+        {
+            return $"APIM-{environment}-{secret}";
+        }
+
+        private static string BuildB2CClientSecretName(string environment, string client, string secret)
+        {
+            return $"B2C-{environment}-{client}-{secret}";
+        }
+
+        private static string BuildB2CEnvironmentSecretName(string environment, string secret)
+        {
+            return $"B2C-{environment}-{secret}";
+        }
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAuthorizationConfiguration.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CAuthorizationConfiguration.cs
@@ -51,12 +51,13 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
 
             var backendAppId = SecretsConfiguration.GetValue<string>(BuildB2CEnvironmentSecretName(Environment, "backend-app-id"));
             BackendApp = new B2CAppSettings(backendAppId);
+            BackendOpenIdConfigurationUrl = $"https://login.microsoftonline.com/{TenantId}/v2.0/.well-known/openid-configuration";
 
             var frontendAppId = SecretsConfiguration.GetValue<string>(BuildB2CEnvironmentSecretName(Environment, "frontend-app-id"));
             FrontendApp = new B2CAppSettings(frontendAppId);
+            FrontendOpenIdConfigurationUrl = SecretsConfiguration.GetValue<string>(BuildB2CEnvironmentSecretName(Environment, "frontend-open-id-url"));
 
             ApiManagementBaseAddress = SecretsConfiguration.GetValue<Uri>(BuildApiManagementEnvironmentSecretName(Environment, "host-url"));
-            FrontendOpenIdUrl = SecretsConfiguration.GetValue<string>(BuildB2CEnvironmentSecretName(Environment, "frontend-open-id-url"));
         }
 
         /// <summary>
@@ -80,14 +81,19 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
         public B2CAppSettings BackendApp { get; }
 
         /// <summary>
+        /// URL of the Open ID configuration for the backend (necessary when validating tokens).
+        /// </summary>
+        public string BackendOpenIdConfigurationUrl { get; }
+
+        /// <summary>
         /// Frontend application ID and scope.
         /// </summary>
         public B2CAppSettings FrontendApp { get; }
 
         /// <summary>
-        /// URL of the Open ID configuration for the frontend.
+        /// URL of the Open ID configuration for the frontend (necessary when validating tokens).
         /// </summary>
-        public string FrontendOpenIdUrl { get; }
+        public string FrontendOpenIdConfigurationUrl { get; }
 
         /// <summary>
         /// The base address for the API Management in the configured environment.

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CClientAppCredentialsSettings.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CClientAppCredentialsSettings.cs
@@ -18,7 +18,15 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
     /// Settings necessary for aquiring an access token for a client app, from the B2C tenant,
     /// using the client credentials flow.
     /// </summary>
-    /// <param name="ClientId"></param>
-    /// <param name="ClientSecret"></param>
-    public record B2CClientAppCredentialsSettings(string ClientId, string ClientSecret);
+    public record B2CClientAppCredentialsSettings
+    {
+        public static B2CClientAppCredentialsSettings Empty { get; }
+            = new();
+
+        public string ClientId { get; internal set; }
+            = string.Empty;
+
+        public string ClientSecret { get; internal set; }
+            = string.Empty;
+    }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CClientAppCredentialsSettings.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CClientAppCredentialsSettings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
+{
+    /// <summary>
+    /// Settings necessary for aquiring an access token for a client app, from the B2C tenant,
+    /// using the client credentials flow.
+    /// </summary>
+    /// <param name="ClientId"></param>
+    /// <param name="ClientSecret"></param>
+    public record B2CClientAppCredentialsSettings(string ClientId, string ClientSecret);
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CClientAppSettings.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CClientAppSettings.cs
@@ -17,7 +17,18 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
     /// <summary>
     /// Name and credential settings for a B2C client app to be used for testing.
     /// </summary>
-    /// <param name="Name">Name of the client app.</param>
-    /// <param name="CredentialSettings">Credential settings necessary for acquiring an access token for the client app.</param>
-    public record B2CClientAppSettings(string Name, B2CClientAppCredentialsSettings CredentialSettings);
+    public record B2CClientAppSettings
+    {
+        /// <summary>
+        /// Name of the client app.
+        /// </summary>
+        public string Name { get; internal set; }
+            = string.Empty;
+
+        /// <summary>
+        /// Credential settings necessary for acquiring an access token for the client app.
+        /// </summary>
+        public B2CClientAppCredentialsSettings CredentialSettings { get; internal set; }
+            = B2CClientAppCredentialsSettings.Empty;
+    }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CClientAppSettings.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/B2C/B2CClientAppSettings.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration.B2C
+{
+    /// <summary>
+    /// Name and credential settings for a B2C client app to be used for testing.
+    /// </summary>
+    /// <param name="Name">Name of the client app.</param>
+    /// <param name="CredentialSettings">Credential settings necessary for acquiring an access token for the client app.</param>
+    public record B2CClientAppSettings(string Name, B2CClientAppCredentialsSettings CredentialSettings);
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>3.2.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.3.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>3.2.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.3.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Move reusable code for B2C test support to Test Common NuGet bundle.

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/413