### PR TITLE
feat: Add extension to filter ServiceBus subscriptions by message type

### DIFF
--- a/source/TestCommon/TestCommon.sln.DotSettings
+++ b/source/TestCommon/TestCommon.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Energinet/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 3.5.0
+
+- Added support for creating message type filters on Service bus subscriptions [Examples](../servicebusresourceprovider.md#examples)
+
 ## Version 3.4.0
 
 - Added support for creating filters on Service bus subscriptions [Examples](../servicebusresourceprovider.md#examples)

--- a/source/TestCommon/documents/servicebusresourceprovider.md
+++ b/source/TestCommon/documents/servicebusresourceprovider.md
@@ -84,13 +84,6 @@ var topicResource = await resourceProvider
     .CreateAsync();
 ```
 
-Clean up:
-
-```csharp
-// Delete resources and close any created sender clients.
-await resourceProvider.DisposeAsync();
-```
-
 Example 3 - creating a subscription with a subject filter
 ```csharp
 var topicResource = await resourceProvider
@@ -98,4 +91,20 @@ var topicResource = await resourceProvider
     .AddSubscription("subscription")
     .AddSubjectFilter("message-subject")
     .CreateAsync();
+```
+
+Example 4 - creating a subscription with a message type filter
+```csharp
+var topicResource = await resourceProvider
+    .BuildTopic("topic")
+    .AddSubscription("subscription")
+    .AddMessageTypeFilter("some-message-type")
+    .CreateAsync();
+```
+
+Clean up:
+
+```csharp
+// Delete resources and close any created sender clients.
+await resourceProvider.DisposeAsync();
 ```

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/ServiceBus/ResourceProvider/ServiceBusResourceProviderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/ServiceBus/ResourceProvider/ServiceBusResourceProviderTests.cs
@@ -370,6 +370,15 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Servic
                 // Assert
                 var topicName = actualResource.Name;
 
+                var count = 0;
+                await foreach (var r in ResourceProviderFixture.AdministrationClient.GetRulesAsync(
+                                   topicName,
+                                   SubscriptionName01))
+                {
+                    count++;
+                }
+
+                count.Should().Be(1);
                 var rule = await ResourceProviderFixture.AdministrationClient.GetRuleAsync(
                     topicName,
                     SubscriptionName01,

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/ServiceBus/ResourceProvider/ServiceBusResourceProviderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/ServiceBus/ResourceProvider/ServiceBusResourceProviderTests.cs
@@ -328,7 +328,7 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Servic
                 var response = await ResourceProviderFixture.AdministrationClient.RuleExistsAsync(
                     topicName,
                     SubscriptionName01,
-                    TopicSubscriptionBuilder.DefaultSubjectRuleName);
+                    TopicSubscriptionBuilderExtensions.DefaultSubjectRuleName);
                 response.Value.Should().BeTrue();
             }
 
@@ -350,8 +350,33 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.Servic
                 var response = await ResourceProviderFixture.AdministrationClient.RuleExistsAsync(
                     topicName,
                     SubscriptionName01,
-                    TopicSubscriptionBuilder.DefaultSubjectAndToRuleName);
+                    TopicSubscriptionBuilderExtensions.DefaultSubjectAndToRuleName);
                 response.Value.Should().BeTrue();
+            }
+
+            [Fact]
+            public async Task When_AddMessageTypeFilter_Then_RuleAdheresToArchitectureDecisionRecord008()
+            {
+                // Arrange
+                var someMessageType = "some-message-type";
+
+                // Act
+                var actualResource = await Sut
+                    .BuildTopic(NamePrefix)
+                    .AddSubscription(SubscriptionName01)
+                    .AddMessageTypeFilter(someMessageType)
+                    .CreateAsync();
+
+                // Assert
+                var topicName = actualResource.Name;
+
+                var rule = await ResourceProviderFixture.AdministrationClient.GetRuleAsync(
+                    topicName,
+                    SubscriptionName01,
+                    TopicSubscriptionBuilderExtensions.MessageTypeRuleName);
+                var filter = (CorrelationRuleFilter)rule.Value.Filter;
+
+                filter.ApplicationProperties["MessageType"].Should().Be(someMessageType);
             }
 
             [Fact]

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>3.4.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.5.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/ServiceBus/ResourceProvider/TopicSubscriptionBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/ServiceBus/ResourceProvider/TopicSubscriptionBuilder.cs
@@ -24,10 +24,6 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvi
     /// </summary>
     public class TopicSubscriptionBuilder : ITopicResourceBuilder
     {
-        public const string DefaultSubjectRuleName = "subject-rule";
-
-        public const string DefaultSubjectAndToRuleName = "subject-to-rule";
-
         internal TopicSubscriptionBuilder(
             TopicResourceBuilder topicResourceBuilder,
             CreateSubscriptionOptions createSubscriptionOptions)
@@ -41,7 +37,7 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvi
 
         internal CreateSubscriptionOptions CreateSubscriptionOptions { get; }
 
-        internal CreateRuleOptions CreateRuleOptions { get; private set; }
+        internal CreateRuleOptions CreateRuleOptions { get; set; }
 
         internal IList<Action<SubscriptionProperties>> PostActions { get; }
 
@@ -74,41 +70,6 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvi
         public Task<TopicResource> CreateAsync()
         {
             return TopicResourceBuilder.CreateAsync();
-        }
-
-        /// <summary>
-        /// Add a subscription rule. Can be used to create a Correlation or SQL filter.
-        /// </summary>
-        public TopicSubscriptionBuilder AddRule(CreateRuleOptions ruleOptions)
-        {
-            if (ruleOptions is null)
-            {
-                throw new ArgumentNullException(nameof(ruleOptions));
-            }
-
-            CreateRuleOptions = ruleOptions;
-
-            return this;
-        }
-
-        /// <summary>
-        /// Add a correlation filter with <see cref="DefaultSubjectRuleName"/> that will filter on Subject.
-        /// </summary>
-        public TopicSubscriptionBuilder AddSubjectFilter(string subject)
-        {
-            CreateRuleOptions = new CreateRuleOptions(DefaultSubjectRuleName, new CorrelationRuleFilter { Subject = subject });
-
-            return this;
-        }
-
-        /// <summary>
-        /// Add a correlation filter with <see cref="DefaultSubjectAndToRuleName"/> that will filter on Subject AND To.
-        /// </summary>
-        public TopicSubscriptionBuilder AddSubjectAndToFilter(string subject, string to)
-        {
-            CreateRuleOptions = new CreateRuleOptions(DefaultSubjectAndToRuleName, new CorrelationRuleFilter { Subject = subject, To = to });
-
-            return this;
         }
     }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon/ServiceBus/ResourceProvider/TopicSubscriptionBuilderExtensions.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/ServiceBus/ResourceProvider/TopicSubscriptionBuilderExtensions.cs
@@ -13,14 +13,77 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using Azure.Messaging.ServiceBus.Administration;
 
 namespace Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvider
 {
     public static class TopicSubscriptionBuilderExtensions
     {
+        public const string DefaultSubjectRuleName = "subject-rule";
+
+        public const string DefaultSubjectAndToRuleName = "subject-to-rule";
+
+        public const string MessageTypeRuleName = "message-type-rule";
+
         public static TopicSubscriptionBuilder SetEnvironmentVariableToSubscriptionName(this TopicSubscriptionBuilder builder, string variable)
         {
             builder.Do(subscriptionProperties => Environment.SetEnvironmentVariable(variable, subscriptionProperties.SubscriptionName));
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Add a subscription rule. Can be used to create a Correlation or SQL filter.
+        /// </summary>
+        public static TopicSubscriptionBuilder AddRule(this TopicSubscriptionBuilder builder, CreateRuleOptions ruleOptions)
+        {
+            if (ruleOptions is null)
+            {
+                throw new ArgumentNullException(nameof(ruleOptions));
+            }
+
+            builder.CreateRuleOptions = ruleOptions;
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Add a correlation filter with <see cref="DefaultSubjectRuleName"/> that will filter on Subject.
+        /// </summary>
+        public static TopicSubscriptionBuilder AddSubjectFilter(this TopicSubscriptionBuilder builder, string subject)
+        {
+            builder.CreateRuleOptions = new CreateRuleOptions(DefaultSubjectRuleName, new CorrelationRuleFilter { Subject = subject });
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Add a correlation filter with <see cref="DefaultSubjectAndToRuleName"/> that will filter on Subject AND To.
+        /// </summary>
+        public static TopicSubscriptionBuilder AddSubjectAndToFilter(this TopicSubscriptionBuilder builder, string subject, string to)
+        {
+            builder.CreateRuleOptions = new CreateRuleOptions(DefaultSubjectAndToRuleName, new CorrelationRuleFilter { Subject = subject, To = to });
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a filter on the message type of the integration events according to ADR-008.
+        /// </summary>
+        public static TopicSubscriptionBuilder AddMessageTypeFilter(this TopicSubscriptionBuilder builder, string messageType)
+        {
+            if (messageType == null) throw new ArgumentNullException(nameof(messageType));
+
+            builder.CreateRuleOptions = new CreateRuleOptions(
+                MessageTypeRuleName,
+                new CorrelationRuleFilter
+                {
+                    ApplicationProperties =
+                    {
+                        new KeyValuePair<string, object>("MessageType", messageType),
+                    },
+                });
 
             return builder;
         }

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>3.4.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.5.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/green-energy-hub) before we can accept your contribution. --->

## Description

Add an extension method to filter ServiceBus subscriptions by message type.
The implementation adheres to ADR-008.

