### PR TITLE
DatabricksSqlStatement package: Add additional log statement to get the `DatabricksSqlResponse.State`

### DIFF
--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Databricks Release Notes
 
+## Version 1.0.4
+
+- No functional change.
+
 ## Version 1.0.3
 
 - No functional change.

--- a/source/Databricks/source/SqlStatementExecution/Internal/SqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/SqlStatementClient.cs
@@ -108,6 +108,11 @@ public class SqlStatementClient : ISqlStatementClient
         var waitTime = 1000;
         while (databricksSqlResponse.State is DatabricksSqlResponseState.Pending or DatabricksSqlResponseState.Running)
         {
+            _logger.LogDebug(
+                "Databricks SQL response received with state: {State} for statement ID: {StatementId}",
+                databricksSqlResponse.State,
+                databricksSqlResponse.StatementId);
+
             if (waitTime > 600000)
             {
                 throw new DatabricksSqlException($"Unable to get calculation result from Databricks because the SQL statement execution didn't succeed. State: {databricksSqlResponse.State}");

--- a/source/Databricks/source/SqlStatementExecution/Internal/SqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/SqlStatementClient.cs
@@ -104,7 +104,7 @@ public class SqlStatementClient : ISqlStatementClient
 
         var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         var databricksSqlResponse = _responseResponseParser.ParseStatusResponse(jsonResponse);
-        LogDatabricksSqlResponse(databricksSqlResponse);
+        LogDatabricksSqlResponseState(databricksSqlResponse);
 
         var waitTime = 1000;
         while (databricksSqlResponse.State is DatabricksSqlResponseState.Pending or DatabricksSqlResponseState.Running)
@@ -127,7 +127,7 @@ public class SqlStatementClient : ISqlStatementClient
 
             jsonResponse = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             databricksSqlResponse = _responseResponseParser.ParseStatusResponse(jsonResponse);
-            LogDatabricksSqlResponse(databricksSqlResponse);
+            LogDatabricksSqlResponseState(databricksSqlResponse);
         }
 
         if (databricksSqlResponse.State is not DatabricksSqlResponseState.Succeeded)
@@ -174,7 +174,7 @@ public class SqlStatementClient : ISqlStatementClient
         httpClient.BaseAddress = new Uri(options.Value.WorkspaceUrl);
     }
 
-    private void LogDatabricksSqlResponse(DatabricksSqlResponse response)
+    private void LogDatabricksSqlResponseState(DatabricksSqlResponse response)
     {
         _logger.LogDebug(
             "Databricks SQL response received with state: {State} for statement ID: {StatementId}",

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>1.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.0.4$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/green-energy-hub) before we can accept your contribution. --->

## Description

Needed to log the state of the databricksSqlResponse in order to test below referenced story. This would make sense to keep, hence this PR.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* https://github.com/Energinet-DataHub/team-volt/issues/50
