### PR TITLE
feat: Parameterized SQL statements to prevent SQL Injections

### DIFF
--- a/source/Databricks/documents/documentation.md
+++ b/source/Databricks/documents/documentation.md
@@ -19,10 +19,10 @@ private static void AddDatabricks(IServiceCollection services, IConfiguration co
     configuration.GetSection("DatabricksOptions").Bind(options);
 
     // Option 1
-    services.AddSqlStatementExecution(options.WarehouseId, options.WorkspaceToken, options.WorkspaceUrl);
+    services.AddDatabricksSqlStatementExecution(options.WarehouseId, options.WorkspaceToken, options.WorkspaceUrl);
 
     // Option 2
-    services.AddSqlStatementExecution(options);
+    services.AddDatabricksSqlStatementExecution(options);
 }
 ```
 
@@ -41,7 +41,7 @@ public async Task<IActionResult> GetAsync()
     var resultList = new List<TestModel>();
 
     await foreach (var row in _databricksSqlStatementClient.ExecuteAsync(sqlQuery, parameters)) {
-        var testModel = new TestModel(row["my_name"],row["my_date"]);
+        var testModel = new TestModel(row["my_name"] ,row["my_date"]);
         resultList.Add(testModel)
     }
 

--- a/source/Databricks/documents/documentation.md
+++ b/source/Databricks/documents/documentation.md
@@ -32,11 +32,16 @@ Example of how to use the SQL Statement Execution client.
 [HttpGet]
 public async Task<IActionResult> GetAsync()
 {
-    var sqlQuery = "SELECT column1 FROM database.table";
+    var sqlQuery = "SELECT * FROM my_table WHERE name = :my_name AND date = :my_date";
+    var parameters = new List<SqlStatementParameter>
+    {
+        new SqlStatementParameter("my_name", "Sheldon Cooper", "STRING"),
+        new SqlStatementParameter("my_date", "26-02-1980", "DATE"),
+    };
     var resultList = new List<TestModel>();
 
-    await foreach (var row in _databricksSqlStatementClient.ExecuteAsync(sqlQuery)) {
-        var testModel = new TestModel(row["column1"]);
+    await foreach (var row in _databricksSqlStatementClient.ExecuteAsync(sqlQuery, parameters)) {
+        var testModel = new TestModel(row["my_name"],row["my_date"]);
         resultList.Add(testModel)
     }
 

--- a/source/Databricks/documents/documentation.md
+++ b/source/Databricks/documents/documentation.md
@@ -41,7 +41,7 @@ public async Task<IActionResult> GetAsync()
     var resultList = new List<TestModel>();
 
     await foreach (var row in _databricksSqlStatementClient.ExecuteAsync(sqlQuery, parameters)) {
-        var testModel = new TestModel(row["my_name"] ,row["my_date"]);
+        var testModel = new TestModel(row["my_name"], row["my_date"]);
         resultList.Add(testModel)
     }
 

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,8 +1,8 @@
 # Databricks Release Notes
 
 ## Version 3.0.0
-- Added support for `SqlStatementParameter` in `ExecuteAsync(string sqlStatement, List<SqlStatementParameter> parameters)`, to prevent SQL Injection.
-- Marked `ExecuteAsync(string sqlStatement)` as obsolete. please use `ExecuteAsync(string, List<SqlStatementParameter>)` instead.
+- Added support for `SqlStatementParameter` in `ExecuteAsync(string, List<SqlStatementParameter>)`, to prevent SQL Injection.
+- Marked `ExecuteAsync(string)` as obsolete. please use `ExecuteAsync(string, List<SqlStatementParameter>)` instead.
 
 ## Version 2.0.0
 

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,6 +1,7 @@
 # Databricks Release Notes
 
 ## Version 3.0.0
+
 - Added support for `SqlStatementParameter` in `ExecuteAsync(string, List<SqlStatementParameter>)`, to prevent SQL Injection.
 - Marked `ExecuteAsync(string)` as obsolete. please use `ExecuteAsync(string, List<SqlStatementParameter>)` instead.
 

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,6 +1,6 @@
 # Databricks Release Notes
 
-## Version 2.1.0
+## Version 3.0.0
 - Added support for `SqlStatementParameter` in `ExecuteAsync(string sqlStatement, List<SqlStatementParameter> parameters)`, to prevent SQL Injection.
 - Marked `ExecuteAsync(string sqlStatement)` as obsolete. please use `ExecuteAsync(string, List<SqlStatementParameter>)` instead.
 

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Databricks Release Notes
 
+## Version 2.1.0
+- Added support for `SqlStatementParameter` in `ExecuteAsync(string sqlStatement, List<SqlStatementParameter> parameters)`, to prevent SQL Injection.
+- Marked `ExecuteAsync(string sqlStatement)` as obsolete. please use `ExecuteAsync(string, List<SqlStatementParameter>)` instead.
+
 ## Version 2.0.0
 
 - See [Version 2.0.0 release notes](./version_2_0_0.md)

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/DatabricksSqlStatementClientObsoleteTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/DatabricksSqlStatementClientObsoleteTests.cs
@@ -1,0 +1,124 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SqlStatementExecution.IntegrationTests.Fixtures;
+
+namespace SqlStatementExecution.IntegrationTests;
+
+[Obsolete("REMOVE THIS TEST CLASS WHEN OBSOLETE METHOD: IAsyncEnumerable<SqlResultRow> ExecuteAsync(string sqlStatement) IS REMOVED")]
+public class DatabricksSqlStatementClientObsoleteTests : IClassFixture<DatabricksSqlStatementApiFixture>, IAsyncLifetime
+{
+    private readonly DatabricksSqlStatementApiFixture _fixture;
+
+    public DatabricksSqlStatementClientObsoleteTests(DatabricksSqlStatementApiFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.DatabricksSchemaManager.CreateSchemaAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DatabricksSchemaManager.DropSchemaAsync();
+    }
+
+    private string SchemaName => _fixture.DatabricksSchemaManager.SchemaName;
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteSqlStatementAsync_WhenQueryFromDatabricks_ReturnsExpectedData(
+        Mock<IHttpClientFactory> httpClientFactory,
+        Mock<ILogger<SqlStatusResponseParser>> databricksSqlStatusResponseParserLoggerMock,
+        Mock<ILogger<DatabricksSqlStatementClient>> sqlStatementClientLoggerMock)
+    {
+        // Arrange
+        var tableName = await CreateResultTableWithTwoRowsAsync();
+        var sut = _fixture.CreateSqlStatementClient(
+            _fixture.DatabricksOptionsMock.Object.Value,
+            httpClientFactory,
+            databricksSqlStatusResponseParserLoggerMock,
+            sqlStatementClientLoggerMock);
+
+        var sqlStatement = $"SELECT * FROM {SchemaName}.{tableName}";
+
+        // Act
+        var actual = await sut.ExecuteAsync(sqlStatement).ToListAsync();
+
+        // Assert
+        actual.Count.Should().Be(2);
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenMultipleChunks_ReturnsAllRows(
+        Mock<IHttpClientFactory> httpClientFactory,
+        Mock<ILogger<SqlStatusResponseParser>> databricksSqlStatusResponseParserLoggerMock,
+        Mock<ILogger<DatabricksSqlStatementClient>> sqlStatementClientLoggerMock)
+    {
+        // Arrange
+        const int expectedRowCount = 100;
+        var sut = _fixture.CreateSqlStatementClient(
+            _fixture.DatabricksOptionsMock.Object.Value,
+            httpClientFactory,
+            databricksSqlStatusResponseParserLoggerMock,
+            sqlStatementClientLoggerMock);
+
+        // Arrange: The result of this query spans multiple chunks
+        var sqlStatement = $"select r.id, 'some value' as value from range({expectedRowCount}) as r";
+
+        // Act
+        var actual = await sut.ExecuteAsync(sqlStatement).CountAsync();
+
+        // Assert
+        actual.Should().Be(expectedRowCount);
+    }
+
+    private async Task<string> CreateResultTableWithTwoRowsAsync()
+    {
+        var (someColumnDefinition, values) = GetSomeDeltaTableRow();
+
+        var tableName = await _fixture.DatabricksSchemaManager.CreateTableAsync(someColumnDefinition);
+        await _fixture.DatabricksSchemaManager.InsertIntoAsync(tableName, values);
+        await _fixture.DatabricksSchemaManager.InsertIntoAsync(tableName, values);
+
+        return tableName;
+    }
+
+    private static (Dictionary<string, string> ColumnDefintion, List<string> Values) GetSomeDeltaTableRow()
+    {
+        var dictionary = new Dictionary<string, string>
+        {
+            { "someTimeColumn", "TIMESTAMP" },
+            { "someStringColumn", "STRING" },
+            { "someDecimalColumn", "DECIMAL(18,3)" },
+        };
+
+        var values = new List<string>
+        {
+            "'2022-03-11T03:00:00.000Z'",
+            "'measured'",
+            "1.234",
+        };
+
+        return (dictionary, values);
+    }
+}

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/DatabricksSqlStatementClientTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/DatabricksSqlStatementClientTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -67,7 +68,9 @@ public class DatabricksSqlStatementClientTests : IClassFixture<DatabricksSqlStat
         var sqlStatement = $"SELECT * FROM {SchemaName}.{tableName}";
 
         // Act
-        var actual = await sut.ExecuteAsync(sqlStatement).ToListAsync();
+        var actual = await sut.ExecuteAsync(
+            sqlStatement,
+            new List<SqlStatementParameter>()).ToListAsync();
 
         // Assert
         actual.Count.Should().Be(2);
@@ -87,12 +90,19 @@ public class DatabricksSqlStatementClientTests : IClassFixture<DatabricksSqlStat
             httpClientFactory,
             databricksSqlStatusResponseParserLoggerMock,
             sqlStatementClientLoggerMock);
+        List<SqlStatementParameter> sqlStatementParameters = new List<SqlStatementParameter>(3)
+        {
+            new SqlStatementParameter("id", "r.id"),
+            new SqlStatementParameter("someValue", "some_value"),
+            new SqlStatementParameter("expectedRowCount", "100", "INT"),
+        };
 
         // Arrange: The result of this query spans multiple chunks
-        var sqlStatement = $"select r.id, 'some value' as value from range({expectedRowCount}) as r";
+        var sqlStatement = $"select :id, :someValue as value from range(:expectedRowCount) as r";
 
         // Act
-        var actual = await sut.ExecuteAsync(sqlStatement).CountAsync();
+        var actual = await sut.ExecuteAsync(sqlStatement, sqlStatementParameters)
+            .CountAsync();
 
         // Assert
         actual.Should().Be(expectedRowCount);

--- a/source/Databricks/source/SqlStatementExecution.Tests/DatabricksSqlStatementClientObsoleteTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.Tests/DatabricksSqlStatementClientObsoleteTests.cs
@@ -1,0 +1,263 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Tests.Builders;
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Tests;
+
+[Obsolete("REMOVE THIS TEST CLASS WHEN OBSOLETE METHOD: IAsyncEnumerable<SqlResultRow> ExecuteAsync(string sqlStatement) IS REMOVED")]
+public class DatabricksSqlStatementObsoleteClientTests
+{
+    private readonly string _running;
+    private readonly string _failed;
+    private readonly string _closed;
+    private readonly string _cancelled;
+    private readonly string _pending;
+
+    private readonly string _calculationResultChunkJson;
+    private readonly string _calculationResultWithExternalLinks;
+    private readonly string _chunkData;
+
+    public DatabricksSqlStatementObsoleteClientTests()
+    {
+        _calculationResultChunkJson = GetJsonFromFile("CalculationResultChunk.json");
+        _calculationResultWithExternalLinks = GetJsonFromFile("CalculationResultWithExternalLinks.json");
+        _chunkData = GetJsonFromFile("ChunkData.json");
+
+        _running = SqlResponseStatusHelper.CreateStatusResponse("RUNNING");
+        _failed = SqlResponseStatusHelper.CreateStatusResponse("FAILED");
+        _closed = SqlResponseStatusHelper.CreateStatusResponse("CLOSED");
+        _cancelled = SqlResponseStatusHelper.CreateStatusResponse("CANCELED");
+        _pending = SqlResponseStatusHelper.CreateStatusResponse("PENDING");
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenFirstRunningThenStatementFails_ThrowsDatabricksSqlException(
+        Guid statementId,
+        Mock<ISqlResponseParser> parserMock,
+        DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_running))
+            .Returns(SqlResponse.CreateAsRunning(statementId));
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_failed))
+            .Returns(SqlResponse.CreateAsFailed(statementId));
+        var sut = builder
+            .AddHttpClientResponse(_running)
+            .AddHttpClientResponse(_failed)
+            .UseParser(parserMock.Object)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenFirstRunningThenStatementIsClosed_ThrowsDatabricksSqlException(
+        Guid statementId,
+        Mock<ISqlResponseParser> parserMock,
+        DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_running))
+            .Returns(SqlResponse.CreateAsRunning(statementId));
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_closed))
+            .Returns(SqlResponse.CreateAsClosed(statementId));
+        var sut = builder
+            .AddHttpClientResponse(_running)
+            .AddHttpClientResponse(_closed)
+            .UseParser(parserMock.Object)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenFirstRunningThenStatementIsCancelled_ThrowsDatabricksSqlException(
+        Guid statementId,
+        Mock<ISqlResponseParser> parserMock,
+        DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_running))
+            .Returns(SqlResponse.CreateAsRunning(statementId));
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_cancelled))
+            .Returns(SqlResponse.CreateAsCancelled(statementId));
+        var sut = builder
+            .AddHttpClientResponse(_running)
+            .AddHttpClientResponse(_cancelled)
+            .UseParser(parserMock.Object)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenFirstPendingThenStatementFails_ThrowsDatabricksSqlException(
+        Guid statementId,
+        Mock<ISqlResponseParser> parserMock,
+        DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_pending))
+            .Returns(SqlResponse.CreateAsPending(statementId));
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_failed))
+            .Returns(SqlResponse.CreateAsFailed(statementId));
+        var sut = builder
+            .AddHttpClientResponse(_pending)
+            .AddHttpClientResponse(_failed)
+            .UseParser(parserMock.Object)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenFirstPendingThenStatementIsClosed_ThrowsDatabricksSqlException(
+        Guid statementId,
+        Mock<ISqlResponseParser> parserMock,
+        DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_pending))
+            .Returns(SqlResponse.CreateAsPending(statementId));
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_closed))
+            .Returns(SqlResponse.CreateAsClosed(statementId));
+        var sut = builder
+            .AddHttpClientResponse(_pending)
+            .AddHttpClientResponse(_closed)
+            .UseParser(parserMock.Object)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenFirstPendingThenStatementIsCancelled_ThrowsDatabricksSqlException(
+        Guid statementId,
+        Mock<ISqlResponseParser> parserMock,
+        DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_pending))
+            .Returns(SqlResponse.CreateAsPending(statementId));
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_cancelled))
+            .Returns(SqlResponse.CreateAsCancelled(statementId));
+        var sut = builder
+            .AddHttpClientResponse(_pending)
+            .AddHttpClientResponse(_cancelled)
+            .UseParser(parserMock.Object)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenHttpRequestFails_ThrowsDatabricksSqlException(DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        var sut = builder
+            .AddHttpClientResponse("http request failed", HttpStatusCode.BadRequest)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenSecondHttpRequestFails_ThrowsDatabricksSqlException(
+        Guid statementId,
+        Mock<ISqlResponseParser> parserMock,
+        DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(_running))
+            .Returns(SqlResponse.CreateAsRunning(statementId));
+        var sut = builder
+            .AddHttpClientResponse(_running)
+            .AddHttpClientResponse("http request failed", HttpStatusCode.BadRequest)
+            .UseParser(parserMock.Object)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenMultipleChunks_GetAllChunks(
+        DatabricksSqlStatementClientBuilder builder)
+    {
+        // Arrange
+        var mockedLogger = new Mock<ILogger<SqlStatusResponseParser>>();
+        var parser = new SqlResponseParser(
+            new SqlStatusResponseParser(
+                mockedLogger.Object,
+                new SqlChunkResponseParser()),
+            new SqlChunkResponseParser(),
+            new SqlChunkDataResponseParser());
+
+        var sut = builder
+            .AddHttpClientResponse(_calculationResultWithExternalLinks)
+            .AddExternalHttpClientResponse(_chunkData)
+            .AddHttpClientResponse(_calculationResultChunkJson)
+            .UseParser(parser)
+            .Build();
+
+        // Act
+        var result = await sut.ExecuteAsync("some sql").ToListAsync();
+
+        // Assert
+        Assert.Equal(5, result.Count);
+    }
+
+    private string GetJsonFromFile(string fileName)
+    {
+        var stream = EmbeddedResources.GetStream(fileName);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/source/Databricks/source/SqlStatementExecution.Tests/DatabricksSqlStatementClientTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.Tests/DatabricksSqlStatementClientTests.cs
@@ -68,7 +68,8 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act and assert
-        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.
+            ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync());
     }
 
     [Theory]
@@ -92,7 +93,8 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act and assert
-        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.
+            ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync());
     }
 
     [Theory]
@@ -116,7 +118,8 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act and assert
-        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.
+            ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync());
     }
 
     [Theory]
@@ -140,7 +143,8 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act and assert
-        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.
+            ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync());
     }
 
     [Theory]
@@ -164,7 +168,8 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act and assert
-        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.
+            ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync());
     }
 
     [Theory]
@@ -188,7 +193,8 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act and assert
-        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.
+            ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync());
     }
 
     [Theory]
@@ -201,7 +207,8 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act and assert
-        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.
+            ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync());
     }
 
     [Theory]
@@ -222,7 +229,8 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act and assert
-        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.
+            ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync());
     }
 
     [Theory]
@@ -247,7 +255,7 @@ public class DatabricksSqlStatementClientTests
             .Build();
 
         // Act
-        var result = await sut.ExecuteAsync("some sql").ToListAsync();
+        var result = await sut.ExecuteAsync("some sql", new List<SqlStatementParameter>()).ToListAsync();
 
         // Assert
         Assert.Equal(5, result.Count);

--- a/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
@@ -40,9 +40,9 @@ public interface IDatabricksSqlStatementClient
     /// Each row is streamed as soon as it becomes available, providing efficient memory usage for large result sets.
     /// </returns>
     /// <remarks>
-    /// Use this method to execute SQL queries against Databricks while ensuring parameterization to protect against SQL injection attacks.
-    /// The <paramref name="sqlStatement"/> should contain placeholders in the form of ':parameterName', and the <paramref name="parameters"/>
-    /// list should provide corresponding <see cref="SqlStatementParameter"/> objects with the name, value, and data type for each parameter.
+    /// Use this method to execute SQL queries against Databricks with parameterization to protect against SQL injection attacks.
+    /// The <paramref name="sqlStatement"/> should contain placeholders in the form of ':parameterName', that has corresponding
+    /// <see cref="SqlStatementParameter"/> objects in the <paramref name="parameters"/> list.
     /// </remarks>
     IAsyncEnumerable<SqlResultRow> ExecuteAsync(
         string sqlStatement,

--- a/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
@@ -33,18 +33,17 @@ public interface IDatabricksSqlStatementClient
     /// Asynchronously executes a parameterized SQL query on Databricks and streams the results.
     /// </summary>
     /// <param name="sqlStatement">The SQL query to be executed, with placeholders for parameters. </param>
-    /// <param name="parameters">A list of <see cref="SqlStatementParameter"/> objects representing parameters
+    /// <param name="sqlStatementParameters">A list of <see cref="SqlStatementParameter"/> objects representing parameters
     /// to be used in the query, preventing SQL injection vulnerabilities.</param>
     /// <returns>
     /// An asynchronous enumerable of <see cref="SqlResultRow"/> representing the result set of the query.
-    /// Each row is streamed as soon as it becomes available, providing efficient memory usage for large result sets.
     /// </returns>
     /// <remarks>
     /// Use this method to execute SQL queries against Databricks with parameterization to protect against SQL injection attacks.
     /// The <paramref name="sqlStatement"/> should contain placeholders in the form of ':parameterName', that has corresponding
-    /// <see cref="SqlStatementParameter"/> objects in the <paramref name="parameters"/> list.
+    /// <see cref="SqlStatementParameter"/> objects in the <paramref name="sqlStatementParameters"/> list.
     /// </remarks>
     IAsyncEnumerable<SqlResultRow> ExecuteAsync(
         string sqlStatement,
-        List<SqlStatementParameter> parameters);
+        List<SqlStatementParameter> sqlStatementParameters);
 }

--- a/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
 
@@ -25,6 +26,7 @@ public interface IDatabricksSqlStatementClient
     /// <summary>
     /// Get all the rows of a SQL query in as an asynchronous data stream.
     /// </summary>
+    [Obsolete("ExecuteAsync(string) is deprecated, please use ExecuteAsync(string, List<SqlStatementParameter>) instead.")]
     IAsyncEnumerable<SqlResultRow> ExecuteAsync(string sqlStatement);
 
     /// <summary>

--- a/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
@@ -30,10 +30,20 @@ public interface IDatabricksSqlStatementClient
     IAsyncEnumerable<SqlResultRow> ExecuteAsync(string sqlStatement);
 
     /// <summary>
-    /// Get all the rows of a SQL query in as an asynchronous data stream.
-    ///
-    /// Uses parameterized queries to prevent SQL injections.
+    /// Asynchronously executes a parameterized SQL query on Databricks and streams the results.
     /// </summary>
+    /// <param name="sqlStatement">The SQL query to be executed, with placeholders for parameters. </param>
+    /// <param name="parameters">A list of <see cref="SqlStatementParameter"/> objects representing parameters
+    /// to be used in the query, preventing SQL injection vulnerabilities.</param>
+    /// <returns>
+    /// An asynchronous enumerable of <see cref="SqlResultRow"/> representing the result set of the query.
+    /// Each row is streamed as soon as it becomes available, providing efficient memory usage for large result sets.
+    /// </returns>
+    /// <remarks>
+    /// Use this method to execute SQL queries against Databricks while ensuring parameterization to protect against SQL injection attacks.
+    /// The <paramref name="sqlStatement"/> should contain placeholders in the form of ':parameterName', and the <paramref name="parameters"/>
+    /// list should provide corresponding <see cref="SqlStatementParameter"/> objects with the name, value, and data type for each parameter.
+    /// </remarks>
     IAsyncEnumerable<SqlResultRow> ExecuteAsync(
         string sqlStatement,
         List<SqlStatementParameter> parameters);

--- a/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/IDatabricksSqlStatementClient.cs
@@ -26,4 +26,13 @@ public interface IDatabricksSqlStatementClient
     /// Get all the rows of a SQL query in as an asynchronous data stream.
     /// </summary>
     IAsyncEnumerable<SqlResultRow> ExecuteAsync(string sqlStatement);
+
+    /// <summary>
+    /// Get all the rows of a SQL query in as an asynchronous data stream.
+    ///
+    /// Uses parameterized queries to prevent SQL injections.
+    /// </summary>
+    IAsyncEnumerable<SqlResultRow> ExecuteAsync(
+        string sqlStatement,
+        List<SqlStatementParameter> parameters);
 }

--- a/source/Databricks/source/SqlStatementExecution/Internal/DatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/DatabricksSqlStatementClient.cs
@@ -57,7 +57,10 @@ public class DatabricksSqlStatementClient : IDatabricksSqlStatementClient
 
     public async IAsyncEnumerable<SqlResultRow> ExecuteAsync(string sqlStatement, List<SqlStatementParameter> sqlStatementParameters)
     {
-        _logger.LogDebug("Executing SQL statement: {Sql}", HttpUtility.HtmlEncode(sqlStatement));
+        _logger.LogDebug(
+            "Executing SQL statement: {Sql}, with parameters: {Parameters}",
+            HttpUtility.HtmlEncode(sqlStatement),
+            sqlStatementParameters);
 
         var response = await GetFirstChunkOrNullAsync(sqlStatement, sqlStatementParameters).ConfigureAwait(false);
         var columnNames = response.ColumnNames;

--- a/source/Databricks/source/SqlStatementExecution/Internal/DatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/DatabricksSqlStatementClient.cs
@@ -90,7 +90,6 @@ public class DatabricksSqlStatementClient : IDatabricksSqlStatementClient
         _logger.LogDebug("SQL statement executed. Rows returned: {RowCount}", rowCount);
     }
 
-    [Obsolete("ExecuteAsync is deprecated, please use ExecuteAsync(string, List<SqlStatementParameter>) instead.")]
     public async IAsyncEnumerable<SqlResultRow> ExecuteAsync(string sqlStatement)
     {
         _logger.LogDebug("Executing SQL statement: {Sql}", HttpUtility.HtmlEncode(sqlStatement));

--- a/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
@@ -21,7 +21,7 @@ namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Model
 /// <remarks>
 /// The <see cref="SqlStatementParameter"/> class is used to define a parameter for a parameterized SQL query.
 /// It encapsulates the name and value of the parameterThe <see cref="Type"/> property is always set to "STRING",
-/// to avoid 3rd party typechecking. If we were to provide types here, Statement Execution would perform typechecking.
+/// to avoid 3rd party type checking. If we were to provide types here, Statement Execution would perform type checking.
 ///
 /// Instances of this class are typically used when constructing parameterized SQL
 /// statements. See <see cref="DatabricksSqlStatementClient"/>

--- a/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
@@ -20,8 +20,8 @@ namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Model
 /// </summary>
 /// <remarks>
 /// The <see cref="SqlStatementParameter"/> class is used to define a parameter for a parameterized SQL query.
-/// It encapsulates the name and value of the parameterThe <see cref="Type"/> property is always set to "STRING",
-/// to avoid 3rd party type checking. If we were to provide types here, Statement Execution would perform type checking.
+/// It encapsulates the name and value of the parameter. The <see cref="Type"/> property is set to "STRING" by default.
+/// If another value is given, Databricks SQL Statement Execution API will perform type checking.
 ///
 /// Instances of this class are typically used when constructing parameterized SQL
 /// statements. See <see cref="DatabricksSqlStatementClient"/>
@@ -41,20 +41,22 @@ public sealed record SqlStatementParameter
     public string Value { get; }
 
     /// <summary>
-    /// Gets the data type of the SQL parameter, which is always "STRING."
+    /// Gets the data type of the SQL parameter, which is "STRING" by default.
     /// </summary>
     [JsonPropertyName("type")]
-    public static string Type => "STRING";
+    public string Type { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlStatementParameter"/> class
-    /// with the specified name and value.
+    /// with the specified name and value, and sets the data type to "STRING" by default.
     /// </summary>
     /// <param name="name">The name of the SQL parameter.</param>
     /// <param name="value">The value of the SQL parameter.</param>
-    public SqlStatementParameter(string name, string value)
+    /// <param name="type">The data type of the SQL parameter (default is "STRING").</param>
+    public SqlStatementParameter(string name, string value, string type = "STRING")
     {
         Name = name;
         Value = value;
+        Type = type;
     }
 }

--- a/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json.Serialization;
+
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
+
+/// <summary>
+/// This class is used to represent a parameter in a SQL statement, for the
+/// Databricks Sql Statement Execution API.
+///
+/// A parameter consists of a name, a value, and optionally a type. To represent a NULL value, the value field
+/// may be omitted or set to null explicitly. If the type field is omitted, the value is interpreted as a string.
+/// </summary>
+public record SqlStatementParameter([property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("value")] string Value,
+    [property: JsonPropertyName("type")] string Type);

--- a/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
@@ -15,14 +15,46 @@
 using System.Text.Json.Serialization;
 
 namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
-
 /// <summary>
-/// This class is used to represent a parameter in a SQL statement, for the
-/// Databricks Sql Statement Execution API.
-///
-/// A parameter consists of a name, a value, and optionally a type. To represent a NULL value, the value field
-/// may be omitted or set to null explicitly. If the type field is omitted, the value is interpreted as a string.
+/// Represents a parameter for a parameterized SQL query.
 /// </summary>
-public record SqlStatementParameter([property: JsonPropertyName("name")] string Name,
-    [property: JsonPropertyName("value")] string Value,
-    [property: JsonPropertyName("type")] string Type);
+/// <remarks>
+/// The <see cref="SqlStatementParameter"/> class is used to define a parameter for a parameterized SQL query.
+/// It encapsulates the name and value of the parameterThe <see cref="Type"/> property is always set to "STRING",
+/// to avoid 3rd party typechecking. If we were to provide types here, Statement Execution would perform typechecking.
+///
+/// Instances of this class are typically used when constructing parameterized SQL
+/// statements. See <see cref="DatabricksSqlStatementClient"/>
+/// </remarks>
+public sealed record SqlStatementParameter
+{
+    /// <summary>
+    /// Gets the name of the SQL parameter.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the value of the SQL parameter.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public string Value { get; }
+
+    /// <summary>
+    /// Gets the data type of the SQL parameter, which is always "STRING."
+    /// </summary>
+    [JsonPropertyName("type")]
+    public static string Type => "STRING";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlStatementParameter"/> class
+    /// with the specified name and value.
+    /// </summary>
+    /// <param name="name">The name of the SQL parameter.</param>
+    /// <param name="value">The value of the SQL parameter.</param>
+    public SqlStatementParameter(string name, string value)
+    {
+        Name = name;
+        Value = value;
+    }
+}

--- a/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
+++ b/source/Databricks/source/SqlStatementExecution/Internal/Models/SqlStatementParameter.cs
@@ -21,7 +21,8 @@ namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Model
 /// <remarks>
 /// The <see cref="SqlStatementParameter"/> class is used to define a parameter for a parameterized SQL query.
 /// It encapsulates the name and value of the parameter. The <see cref="Type"/> property is set to "STRING" by default.
-/// If another value is given, Databricks SQL Statement Execution API will perform type checking.
+/// If another type is given, Databricks SQL Statement Execution API will perform type checking.
+/// (See 'parameters' at https://docs.databricks.com/api/workspace/statementexecution/executestatement).
 ///
 /// Instances of this class are typically used when constructing parameterized SQL
 /// statements. See <see cref="DatabricksSqlStatementClient"/>

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>99.99.90$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>99.99.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>99.99.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>99.99.3$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>99.99.90$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>99.99.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

This pull requests builds upon the Databricks SQL Statement Execution API package. It will make the method `ExecuteAsync(string)` obsolete, and instead refer to the use of `ExecuteAsync(String, List<SqlStatementParameter>`. The new method will use SQL statement with [placeholders/parameter markers](https://docs.databricks.com/en/sql/language-manual/sql-ref-parameter-marker.html), to prevent sql injection. 

## Quality

- [✔️] Documentation is updated
- [✔️] Release notes are updated
- [✔️] Package version is updated
- [✔️] Public types and methods are documented
- [✔️] Tests are implemented and executed locally
