### PR TITLE
refac: Remove "Internal" namespace

### DIFF
--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Databricks Release Notes
 
+## Version 7.1.2
+
+- The "Internal" namespace is removed, and related code is grouped in relevant namespaces. 
+
 ## Version 7.1.1
 
 - No functional change.

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 7.1.2
 
-- The "Internal" namespace is removed, and related code is grouped in relevant namespaces. 
+- The "Internal" namespace is removed, and related code is grouped in relevant namespaces.
 
 ## Version 7.1.1
 

--- a/source/Databricks/source/Jobs.UnitTests/Client/JobsApiClientTests.cs
+++ b/source/Databricks/source/Jobs.UnitTests/Client/JobsApiClientTests.cs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.Databricks.Jobs.Configuration;
-using Energinet.DataHub.Core.Databricks.Jobs.Internal;
+using Energinet.DataHub.Core.Databricks.Jobs.Client;
 using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Energinet.DataHub.Core.Databricks.Jobs.UnitTests.Internal;
+namespace Energinet.DataHub.Core.Databricks.Jobs.UnitTests.Client;
 
 public class JobsApiClientTests
 {

--- a/source/Databricks/source/Jobs.UnitTests/Extensions/DependencyInjection/DatabricksJobsExtensionsTests.cs
+++ b/source/Databricks/source/Jobs.UnitTests/Extensions/DependencyInjection/DatabricksJobsExtensionsTests.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.Databricks.Jobs.Abstractions;
+using Energinet.DataHub.Core.Databricks.Jobs.Client;
+using Energinet.DataHub.Core.Databricks.Jobs.Constants;
 using Energinet.DataHub.Core.Databricks.Jobs.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.Databricks.Jobs.Internal;
-using Energinet.DataHub.Core.Databricks.Jobs.Internal.Constants;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/source/Databricks/source/Jobs/Client/JobsApiClient.cs
+++ b/source/Databricks/source/Jobs/Client/JobsApiClient.cs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.Databricks.Jobs.Abstractions;
-using Energinet.DataHub.Core.Databricks.Jobs.Internal.Constants;
+using Energinet.DataHub.Core.Databricks.Jobs.Constants;
 using Microsoft.Azure.Databricks.Client;
 
-namespace Energinet.DataHub.Core.Databricks.Jobs.Internal
+namespace Energinet.DataHub.Core.Databricks.Jobs.Client
 {
     /// <summary>
     /// A databricks client based on the Microsoft.Azure.JobsApiClient, which is using Job API 2.0.

--- a/source/Databricks/source/Jobs/Constants/HttpClientNameConstants.cs
+++ b/source/Databricks/source/Jobs/Constants/HttpClientNameConstants.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Energinet.DataHub.Core.Databricks.Jobs.Internal.Constants;
+namespace Energinet.DataHub.Core.Databricks.Jobs.Constants;
 
 /// <summary>
 /// Constants used for naming <see cref="HttpClient"/> instances.

--- a/source/Databricks/source/Jobs/Extensions/DependencyInjection/DatabricksJobsExtensions.cs
+++ b/source/Databricks/source/Jobs/Extensions/DependencyInjection/DatabricksJobsExtensions.cs
@@ -15,9 +15,9 @@
 using System.Net;
 using System.Net.Http.Headers;
 using Energinet.DataHub.Core.Databricks.Jobs.Abstractions;
+using Energinet.DataHub.Core.Databricks.Jobs.Client;
 using Energinet.DataHub.Core.Databricks.Jobs.Configuration;
-using Energinet.DataHub.Core.Databricks.Jobs.Internal;
-using Energinet.DataHub.Core.Databricks.Jobs.Internal.Constants;
+using Energinet.DataHub.Core.Databricks.Jobs.Constants;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
     <PropertyGroup>
         <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-        <PackageVersion>7.1.1$(VersionSuffix)</PackageVersion>
+        <PackageVersion>7.1.2$(VersionSuffix)</PackageVersion>
         <Title>Databricks Jobs</Title>
         <Company>Energinet-DataHub</Company>
         <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/DatabricksSqlStatementClientTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/DatabricksSqlStatementClientTests.cs
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Client;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.IntegrationTests.Fixtures;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.IntegrationTests;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.IntegrationTests.Client;
 
 /// <summary>
 /// We use an IClassFixture to control the life cycle of the DatabricksSqlStatementApiFixture so:

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Fixtures/DatabricksSchemaManager.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Fixtures/DatabricksSchemaManager.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Configuration;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Fixtures/DatabricksSqlStatementApiFixture.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Fixtures/DatabricksSqlStatementApiFixture.cs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Client;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Configuration;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Constants;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Constants;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/AppSettings/DatabricksSqlStatementOptionsTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/AppSettings/DatabricksSqlStatementOptionsTests.cs
@@ -15,7 +15,7 @@
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Configuration;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Configuration;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.AppSettings;
 
 public class DatabricksSqlStatementOptionsTests
 {

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/Builders/DatabricksSqlStatementClientBuilder.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/Builders/DatabricksSqlStatementClientBuilder.cs
@@ -14,9 +14,9 @@
 
 using System.Net;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Client;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Configuration;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Constants;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Constants;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/Client/DatabricksSqlStatementClientTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/Client/DatabricksSqlStatementClientTests.cs
@@ -14,15 +14,15 @@
 
 using System.Net;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Builders;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using Microsoft.Extensions.Logging;
 using Moq;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Client;
 
 public class DatabricksSqlStatementClientTests
 {

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/Extensions/DependencyInjection/DatabricksSqlStatementExecutionExtensionsTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/Extensions/DependencyInjection/DatabricksSqlStatementExecutionExtensionsTests.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Client;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Constants;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Constants;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Helpers;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.Configuration;

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/ResponseParsers/SqlChunkDataResponseParserTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/ResponseParsers/SqlChunkDataResponseParserTests.cs
@@ -14,9 +14,9 @@
 
 using System.Text;
 using AutoFixture.Xunit2;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Internal
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.ResponseParsers
 {
     public class SqlChunkDataResponseParserTests
     {

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/ResponseParsers/SqlChunkResponseParserTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/ResponseParsers/SqlChunkResponseParserTests.cs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.ResponseParsers;
 
 public class SqlChunkResponseParserTests
 {

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/ResponseParsers/SqlResponseParserTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/ResponseParsers/SqlResponseParserTests.cs
@@ -14,15 +14,16 @@
 
 using AutoFixture.Xunit2;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit.Categories;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.ResponseParsers;
 
 [UnitTest]
 public class SqlResponseParserTests

--- a/source/Databricks/source/SqlStatementExecution/Abstractions/IDatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/Abstractions/IDatabricksSqlStatementClient.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
 
 namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;

--- a/source/Databricks/source/SqlStatementExecution/Client/DatabricksSqlStatementClient.cs
+++ b/source/Databricks/source/SqlStatementExecution/Client/DatabricksSqlStatementClient.cs
@@ -14,21 +14,19 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Net.Http.Json;
-using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Configuration;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Constants;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Constants;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Client;
 
 /// <summary>
 /// A client to execute SQL statements against Databricks.
@@ -157,6 +155,7 @@ public class DatabricksSqlStatementClient : IDatabricksSqlStatementClient
 
             waitTime *= 2;
             await Task.Delay(waitTime).ConfigureAwait(false);
+            Console.WriteLine($"Waiting {waitTime}ms for SQL statement to finish");
 
             var path = $"{StatementsEndpointPath}/{databricksSqlResponse.StatementId}";
             var httpResponse = await _httpClient.GetAsync(path).ConfigureAwait(false);

--- a/source/Databricks/source/SqlStatementExecution/Constants/HttpClientNameConstants.cs
+++ b/source/Databricks/source/SqlStatementExecution/Constants/HttpClientNameConstants.cs
@@ -14,7 +14,7 @@
 
 using System.Net.Http;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Constants;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Constants;
 
 /// <summary>
 /// Constants used for naming <see cref="HttpClient"/> instances.

--- a/source/Databricks/source/SqlStatementExecution/Exceptions/DatabricksSqlException.cs
+++ b/source/Databricks/source/SqlStatementExecution/Exceptions/DatabricksSqlException.cs
@@ -14,7 +14,7 @@
 
 using System;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 
 public class DatabricksSqlException : Exception
 {

--- a/source/Databricks/source/SqlStatementExecution/Extensions/DependencyInjection/DatabricksSqlStatementExecutionExtensions.cs
+++ b/source/Databricks/source/SqlStatementExecution/Extensions/DependencyInjection/DatabricksSqlStatementExecutionExtensions.cs
@@ -15,9 +15,10 @@
 using System;
 using System.Net.Http.Headers;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Client;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Configuration;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
-using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Constants;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Constants;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/source/Databricks/source/SqlStatementExecution/Models/SqlStatementParameter.cs
+++ b/source/Databricks/source/SqlStatementExecution/Models/SqlStatementParameter.cs
@@ -14,7 +14,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal.Models;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
 /// <summary>
 /// Represents a parameter for a parameterized SQL query.
 /// </summary>

--- a/source/Databricks/source/SqlStatementExecution/ResponseParsers/SqlChunkDataResponseParser.cs
+++ b/source/Databricks/source/SqlStatementExecution/ResponseParsers/SqlChunkDataResponseParser.cs
@@ -16,12 +16,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 
 public class SqlChunkDataResponseParser : ISqlChunkDataResponseParser
 {

--- a/source/Databricks/source/SqlStatementExecution/ResponseParsers/SqlChunkResponseParser.cs
+++ b/source/Databricks/source/SqlStatementExecution/ResponseParsers/SqlChunkResponseParser.cs
@@ -18,7 +18,7 @@ using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 
 public class SqlChunkResponseParser : ISqlChunkResponseParser
 {

--- a/source/Databricks/source/SqlStatementExecution/ResponseParsers/SqlResponseParser.cs
+++ b/source/Databricks/source/SqlStatementExecution/ResponseParsers/SqlResponseParser.cs
@@ -17,7 +17,7 @@ using System.IO;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 
 public class SqlResponseParser : ISqlResponseParser
 {

--- a/source/Databricks/source/SqlStatementExecution/ResponseParsers/SqlStatusResponseParser.cs
+++ b/source/Databricks/source/SqlStatementExecution/ResponseParsers/SqlStatusResponseParser.cs
@@ -15,12 +15,13 @@
 using System;
 using System.Linq;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Abstractions;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Internal;
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.ResponseParsers;
 
 public class SqlStatusResponseParser : ISqlStatusResponseParser
 {

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>7.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>7.1.2$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

As suggested by @dstenroejl in [this comment](https://github.com/Energinet-DataHub/geh-core/pull/241#pullrequestreview-1639645865) on an earlier pull request, we remove the "Internal" namespace and group related code in relevant namespaces.

## Quality

- [X] Documentation is updated
- [X] Release notes are updated
- [X] Package version is updated
- [X] Public types and methods are documented
- [X] Tests are implemented and executed locally
