### PR TITLE
Improve execution of integration tests

### DIFF
--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
     <PropertyGroup>
         <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-        <PackageVersion>7.2.0$(VersionSuffix)</PackageVersion>
+        <PackageVersion>7.2.1$(VersionSuffix)</PackageVersion>
         <Title>Databricks Jobs</Title>
         <Company>Energinet-DataHub</Company>
         <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Fixtures/DatabricksSqlWarehouseFixture.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Fixtures/DatabricksSqlWarehouseFixture.cs
@@ -22,6 +22,8 @@ namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.IntegrationTes
 
 public sealed class DatabricksSqlWarehouseFixture
 {
+    private static readonly Lazy<IntegrationTestConfiguration> _lazyConfiguration = new(() => new IntegrationTestConfiguration());
+
     public DatabricksSqlWarehouseQueryExecutor CreateSqlStatementClient()
     {
         var services = CreateServiceCollection();
@@ -31,7 +33,7 @@ public sealed class DatabricksSqlWarehouseFixture
 
     private static ServiceCollection CreateServiceCollection()
     {
-        var integrationTestConfiguration = new IntegrationTestConfiguration();
+        var integrationTestConfiguration = _lazyConfiguration.Value;
         var config = new Dictionary<string, string>
         {
             { $"{DatabricksSqlStatementOptions.DatabricksOptions}:WorkspaceUrl", integrationTestConfiguration.DatabricksSettings.WorkspaceUrl },

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>7.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>7.2.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

By cacheing our configuration we can speedup the execution of integration tests 

## Quality

- [ ] Documentation is updated
- [ ] Release notes are updated
- [ ] Package version is updated
- [ ] Public types and methods are documented
- [ ] Tests are implemented and executed locally
