### PR TITLE
refac: playground renamed to domain-test

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 4.4.2
 
-- Bump version as part of renaming Databricks keys in keyvault
+- Databricks integration test configuration keys in keyvault are renamed
 
 ## Version 4.4.1
 

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 4.4.2
+
+- Bump version as part of renaming Databricks keys in keyvault 
+
 ## Version 4.4.1
 
 - No functional change

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 4.4.2
 
-- Bump version as part of renaming Databricks keys in keyvault 
+- Bump version as part of renaming Databricks keys in keyvault
 
 ## Version 4.4.1
 

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/IntegrationTestConfiguration.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/IntegrationTestConfiguration.cs
@@ -126,8 +126,8 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration
             return new DatabricksSettings
             {
                 // We have to build the URL here in code as currently this is also what happens in the infrastructure code (terraform).
-                WorkspaceUrl = $"https://{configuration.GetValue("dbw-playground-workspace-url")}",
-                WorkspaceAccessToken = configuration.GetValue("dbw-playground-workspace-token"),
+                WorkspaceUrl = $"https://{configuration.GetValue("dbw-domain-test-workspace-url")}",
+                WorkspaceAccessToken = configuration.GetValue("dbw-domain-test-workspace-token"),
                 WarehouseId = configuration.GetValue("dbw-sql-endpoint-id"),
             };
         }

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>4.4.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.4.2$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>4.4.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.4.2$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
Databricks keys in keyvault are renamed, version bump