### PR TITLE
feat: Add typed create method to messaging package

### DIFF
--- a/source/Messaging/documents/release-notes/release-notes.md
+++ b/source/Messaging/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Messaging Release notes
 
+## Version 3.2.0
+
+- Support for the `ServiceBusReceivedMessage` type when creating a new `IntegrationEventServiceBusMessage`
+
 ## Version 3.1.1
 
 - No functional change.

--- a/source/Messaging/source/Messaging/IntegrationEventServiceBusMessage.cs
+++ b/source/Messaging/source/Messaging/IntegrationEventServiceBusMessage.cs
@@ -36,6 +36,11 @@ public sealed class IntegrationEventServiceBusMessage
 
     public BinaryData Body { get; }
 
+    /// <summary>
+    /// Create a <see cref="IntegrationEventServiceBusMessage"/>
+    /// </summary>
+    /// <param name="message">The Service Bus message body as a byte array</param>
+    /// <param name="bindingData">The binding data of the Service Bus message, usually retrieved through the binding context</param>
     public static IntegrationEventServiceBusMessage Create(byte[] message, IReadOnlyDictionary<string, object> bindingData)
     {
         var messageId = bindingData["MessageId"] as string ?? throw new InvalidOperationException("MessageId is null");
@@ -50,6 +55,10 @@ public sealed class IntegrationEventServiceBusMessage
         return CreateIntegrationEventServiceBusMessage(messageId, subject, applicationProperties, body);
     }
 
+    /// <summary>
+    /// Create a <see cref="IntegrationEventServiceBusMessage"/>
+    /// </summary>
+    /// <param name="message">The <see cref="ServiceBusReceivedMessage"/> is usually received from an Azure Service Bus</param>
     public static IntegrationEventServiceBusMessage Create(ServiceBusReceivedMessage message)
     {
         return CreateIntegrationEventServiceBusMessage(message.MessageId, message.Subject, message.ApplicationProperties, message.Body);

--- a/source/Messaging/source/Messaging/Messaging.csproj
+++ b/source/Messaging/source/Messaging/Messaging.csproj
@@ -34,7 +34,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Messaging</PackageId>
-    <PackageVersion>3.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.2.0$(VersionSuffix)</PackageVersion>
     <Title>Messaging library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Add create method that uses the `ServiceBusReceivedMessage` type to the `Energinet.DataHub.Core.Messaging` package

## Quality

~- [ ] Documentation is updated~ (the PR doesn't affect the current documentation)
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented

~- [ ] Tests are implemented and executed locally~ (there are no tests in the Messaging package)
