### PR TITLE
Enable test proving telemetry is working with application insights

### DIFF
--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # App Release notes
 
+## Version 8.3.0
+
+- Updated package version for `Energinet.DataHub.Core.JsonSerialization`.
+
 ## Version 8.2.1
 
 - No functional change

--- a/source/App/source/Common.Abstractions/Common.Abstractions.csproj
+++ b/source/App/source/Common.Abstractions/Common.Abstractions.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Abstractions</PackageId>
-    <PackageVersion>8.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.3.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Security/Common.Security.csproj
+++ b/source/App/source/Common.Security/Common.Security.csproj
@@ -26,7 +26,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Security</PackageId>
-    <PackageVersion>8.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.3.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Security Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Tests/Common.Tests.csproj
+++ b/source/App/source/Common.Tests/Common.Tests.csproj
@@ -25,9 +25,9 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.5.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="WireMock.Net" Version="1.5.13" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/source/App/source/Common/Common.csproj
+++ b/source/App/source/Common/Common.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common</PackageId>
-    <PackageVersion>8.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.3.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/ExampleHost.FunctionApp.Tests/ExampleHost.FunctionApp.Tests.csproj
+++ b/source/App/source/ExampleHost.FunctionApp.Tests/ExampleHost.FunctionApp.Tests.csproj
@@ -25,12 +25,12 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.1.0" />
-    <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/App/source/ExampleHost.FunctionApp.Tests/Fixtures/ExampleHostsFixture.cs
+++ b/source/App/source/ExampleHost.FunctionApp.Tests/Fixtures/ExampleHostsFixture.cs
@@ -132,7 +132,7 @@ namespace ExampleHost.FunctionApp.Tests.Fixtures
             appHostSettings.Port = ++port;
 
             appHostSettings.ProcessEnvironmentVariables.Add("AzureWebJobsStorage", "UseDevelopmentStorage=true");
-            appHostSettings.ProcessEnvironmentVariables.Add("APPINSIGHTS_INSTRUMENTATIONKEY", IntegrationTestConfiguration.ApplicationInsightsInstrumentationKey);
+            appHostSettings.ProcessEnvironmentVariables.Add("APPLICATIONINSIGHTS_CONNECTION_STRING", IntegrationTestConfiguration.ApplicationInsightsConnectionString);
 
             return appHostSettings;
         }

--- a/source/App/source/ExampleHost.FunctionApp.Tests/Integration/ExampleHostsFlowTests.cs
+++ b/source/App/source/ExampleHost.FunctionApp.Tests/Integration/ExampleHostsFlowTests.cs
@@ -183,7 +183,7 @@ namespace ExampleHost.FunctionApp.Tests.Integration
                 .Replace("{{$receiveMessageInvocationId}}", receiveMessageInvocationId)
                 .Replace("\n", string.Empty);
 
-            var queryTimerange = new QueryTimeRange(TimeSpan.FromMinutes(20));
+            var queryTimeRange = new QueryTimeRange(TimeSpan.FromMinutes(20));
             var waitLimit = TimeSpan.FromMinutes(20);
             var delay = TimeSpan.FromSeconds(50);
 
@@ -197,7 +197,7 @@ namespace ExampleHost.FunctionApp.Tests.Integration
                         var actualResponse = await Fixture.LogsQueryClient.QueryWorkspaceAsync<QueryResult>(
                             Fixture.LogAnalyticsWorkspaceId,
                             query,
-                            queryTimerange);
+                            queryTimeRange);
 
                         actualCount = actualResponse.Value.Count;
                         return ContainsExpectedEvents(expectedEvents, actualResponse.Value, traceParentTestData);

--- a/source/App/source/ExampleHost.FunctionApp01/Common/EnvironmentSettingNames.cs
+++ b/source/App/source/ExampleHost.FunctionApp01/Common/EnvironmentSettingNames.cs
@@ -19,9 +19,6 @@ namespace ExampleHost.FunctionApp01.Common
     /// </summary>
     public static class EnvironmentSettingNames
     {
-        public const string AzureWebJobsStorage = "AzureWebJobsStorage";
-        public const string AppInsightsInstrumentationKey = "APPINSIGHTS_INSTRUMENTATIONKEY";
-
         public const string IntegrationEventConnectionString = "INTEGRATIONEVENT_CONNECTION_STRING";
         public const string IntegrationEventTopicName = "INTEGRATIONEVENT_TOPIC_NAME";
     }

--- a/source/App/source/ExampleHost.FunctionApp01/local.settings.sample.json
+++ b/source/App/source/ExampleHost.FunctionApp01/local.settings.sample.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
 
-    "APPINSIGHTS_INSTRUMENTATIONKEY": "<app insights instrumentation key>",
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "<app insights connection string>",
 
     "INTEGRATIONEVENT_CONNECTION_STRING": "<connection string>",
     "INTEGRATIONEVENT_TOPIC_NAME": "<topic name>"

--- a/source/App/source/ExampleHost.FunctionApp02/Common/EnvironmentSettingNames.cs
+++ b/source/App/source/ExampleHost.FunctionApp02/Common/EnvironmentSettingNames.cs
@@ -19,9 +19,6 @@ namespace ExampleHost.FunctionApp02.Common
     /// </summary>
     public static class EnvironmentSettingNames
     {
-        public const string AzureWebJobsStorage = "AzureWebJobsStorage";
-        public const string AppInsightsInstrumentationKey = "APPINSIGHTS_INSTRUMENTATIONKEY";
-
         public const string IntegrationEventConnectionString = "INTEGRATIONEVENT_CONNECTION_STRING";
         public const string IntegrationEventTopicName = "INTEGRATIONEVENT_TOPIC_NAME";
         public const string IntegrationEventSubscriptionName = "INTEGRATIONEVENT_SUBSCRIPTION_NAME";

--- a/source/App/source/ExampleHost.FunctionApp02/local.settings.sample.json
+++ b/source/App/source/ExampleHost.FunctionApp02/local.settings.sample.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
 
-    "APPINSIGHTS_INSTRUMENTATIONKEY": "<app insights instrumentation key>",
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "<app insights connection string>",
 
     "INTEGRATIONEVENT_CONNECTION_STRING": "<connection string>",
     "INTEGRATIONEVENT_TOPIC_NAME": "<topic name>",

--- a/source/App/source/ExampleHost.WebApi.Tests/ExampleHost.WebApi.Tests.csproj
+++ b/source/App/source/ExampleHost.WebApi.Tests/ExampleHost.WebApi.Tests.csproj
@@ -25,8 +25,8 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.Query" Version="1.1.0" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/App/source/ExampleHost.WebApi.Tests/Fixtures/AuthenticationHostFixture.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Fixtures/AuthenticationHostFixture.cs
@@ -40,7 +40,7 @@ namespace ExampleHost.WebApi.Tests.Fixtures
         {
             IntegrationTestConfiguration = new IntegrationTestConfiguration();
 
-            Environment.SetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY", IntegrationTestConfiguration.ApplicationInsightsInstrumentationKey);
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", IntegrationTestConfiguration.ApplicationInsightsConnectionString);
 
             AuthorizationConfiguration = new B2CAuthorizationConfiguration(
                 usedForSystemTests: false,

--- a/source/App/source/ExampleHost.WebApi.Tests/Fixtures/AuthorizationHostFixture.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Fixtures/AuthorizationHostFixture.cs
@@ -26,7 +26,7 @@ namespace ExampleHost.WebApi.Tests.Fixtures
             var web03BaseUrl = "http://localhost:5002";
 
             IntegrationTestConfiguration = new IntegrationTestConfiguration();
-            Environment.SetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY", IntegrationTestConfiguration.ApplicationInsightsInstrumentationKey);
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", IntegrationTestConfiguration.ApplicationInsightsConnectionString);
 
             // We cannot use TestServer as this would not work with Application Insights.
             Web03Host = WebHost.CreateDefaultBuilder()

--- a/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
@@ -34,7 +34,7 @@ namespace ExampleHost.WebApi.Tests.Fixtures
             IntegrationTestConfiguration = new IntegrationTestConfiguration();
             Environment.SetEnvironmentVariable(
                 "APPLICATIONINSIGHTS_CONNECTION_STRING",
-                IntegrationTestConfiguration.Configuration.GetValue("AZURE-APPINSIGHTS-CONNECTIONSTRING"));
+                IntegrationTestConfiguration.ApplicationInsightsConnectionString);
 
             // We cannot use TestServer as this would not work with Application Insights.
             Web02Host = WebHost.CreateDefaultBuilder()

--- a/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
@@ -14,6 +14,7 @@
 
 using Azure.Identity;
 using Azure.Monitor.Query;
+using Energinet.DataHub.Core.FunctionApp.TestCommon;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using ExampleHost.WebApi01;
 using Microsoft.AspNetCore;
@@ -31,7 +32,9 @@ namespace ExampleHost.WebApi.Tests.Fixtures
             var web01BaseUrl = "http://localhost:5000";
 
             IntegrationTestConfiguration = new IntegrationTestConfiguration();
-            Environment.SetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY", IntegrationTestConfiguration.ApplicationInsightsInstrumentationKey);
+            Environment.SetEnvironmentVariable(
+                "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                IntegrationTestConfiguration.Configuration.GetValue("AZURE-APPINSIGHTS-CONNECTIONSTRING"));
 
             // We cannot use TestServer as this would not work with Application Insights.
             Web02Host = WebHost.CreateDefaultBuilder()

--- a/source/App/source/ExampleHost.WebApi.Tests/Integration/ExampleHostTests.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Integration/ExampleHostTests.cs
@@ -89,7 +89,7 @@ namespace ExampleHost.WebApi.Tests.Integration
         ///     services.AddApplicationInsightsTelemetry();
         /// </code>
         /// </summary>
-        [Fact(Skip = "Failing even though we haven't changed any code. Will investigate in a separate PR.")]
+        [Fact]
         public async Task Configuration_Should_CauseExpectedEventsToBeLogged()
         {
             var requestIdentification = Guid.NewGuid().ToString();

--- a/source/App/source/ExampleHost.WebApi.Tests/Integration/ExampleHostTests.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Integration/ExampleHostTests.cs
@@ -124,7 +124,7 @@ namespace ExampleHost.WebApi.Tests.Integration
                 .Replace("{{requestIdentification}}", requestIdentification)
                 .Replace("\n", string.Empty);
 
-            var queryTimerange = new QueryTimeRange(TimeSpan.FromMinutes(20));
+            var queryTimeRange = new QueryTimeRange(TimeSpan.FromMinutes(20));
             var waitLimit = TimeSpan.FromMinutes(20);
             var delay = TimeSpan.FromSeconds(50);
 
@@ -138,7 +138,7 @@ namespace ExampleHost.WebApi.Tests.Integration
                         var actualResponse = await Fixture.LogsQueryClient.QueryWorkspaceAsync<QueryResult>(
                             Fixture.LogAnalyticsWorkspaceId,
                             query,
-                            queryTimerange);
+                            queryTimeRange);
 
                         actualCount = actualResponse.Value.Count;
                         return ContainsExpectedEvents(expectedEvents, actualResponse.Value);

--- a/source/App/source/ExampleHost.WebApi01/Startup.cs
+++ b/source/App/source/ExampleHost.WebApi01/Startup.cs
@@ -50,7 +50,8 @@ namespace ExampleHost.WebApi01
             });
 
             services.AddHostedService<SomeTrigger>();
-            services.AddScoped<SomeTrigger.SomeWorker>();
+            services.AddSingleton<SomeTrigger.SomeWorker>();
+            services.AddSingleton<SomeTrigger.SomeWorker.Thrower>();
 
             services
                 .AddHealthChecks()

--- a/source/App/source/ExampleHost.WebApi01/Startup.cs
+++ b/source/App/source/ExampleHost.WebApi01/Startup.cs
@@ -15,6 +15,7 @@
 using Energinet.DataHub.Core.App.Common.Diagnostics.HealthChecks;
 using Energinet.DataHub.Core.App.WebApp.Diagnostics.HealthChecks;
 using ExampleHost.WebApi01.Common;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace ExampleHost.WebApi01
 {
@@ -51,7 +52,8 @@ namespace ExampleHost.WebApi01
 
             services.AddHostedService<SomeTrigger>();
             services.AddSingleton<SomeTrigger.SomeWorker>();
-            services.AddSingleton<SomeTrigger.SomeWorker.Thrower>();
+            // Ensure we register the "Thrower" if we start the hot locally, but not if this was already registered by tests.
+            services.TryAddSingleton<SomeTrigger.SomeWorker.Thrower>();
 
             services
                 .AddHealthChecks()

--- a/source/App/source/FunctionApp.Tests/FunctionApp.Tests.csproj
+++ b/source/App/source/FunctionApp.Tests/FunctionApp.Tests.csproj
@@ -29,10 +29,10 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.5.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp</PackageId>
-    <PackageVersion>8.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.3.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -69,7 +69,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Core" Version="6.0.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-    <PackageReference Include="Energinet.DataHub.Core.JsonSerialization" Version="2.1.1" />
+    <PackageReference Include="Energinet.DataHub.Core.JsonSerialization" Version="2.2.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/App/source/WebApp.Tests/WebApp.Tests.csproj
+++ b/source/App/source/WebApp.Tests/WebApp.Tests.csproj
@@ -27,12 +27,12 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
+        <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.5.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.10" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Moq" Version="4.18.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/App/source/WebApp/WebApp.csproj
+++ b/source/App/source/WebApp/WebApp.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp</PackageId>
-    <PackageVersion>8.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.3.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Web App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
- [x] Enable test of telemetry, that was previously skipped
- [x] Fix scoping issues so web app can be started locally
- [x] Use Application Insights connection string instead of instrumentation key