### PR TITLE
Support setting TransportType for ServiceBusClient

### DIFF
--- a/source/Messaging/documents/release-notes/release-notes.md
+++ b/source/Messaging/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Messaging Release notes
 
+## Version 3.3.0
+
+- Extend `PublisherOptions` and `SubscriberWorkerOptions` with `TransportType` to allow consumers to decide the transport used when communicating with Service Bus.
+
 ## Version 3.2.1
 
 - No functional change

--- a/source/Messaging/source/Messaging/Internal/Publisher/ServiceBusSenderProvider.cs
+++ b/source/Messaging/source/Messaging/Internal/Publisher/ServiceBusSenderProvider.cs
@@ -29,6 +29,16 @@ internal sealed class ServiceBusSenderProvider : IServiceBusSenderProvider
     }
 
     public ServiceBusSender Instance
-        => _serviceBusSender ??= new ServiceBusClient(_options.Value.ServiceBusConnectionString)
+        => _serviceBusSender ??= CreateServiceBusClient()
             .CreateSender(_options.Value.TopicName);
+
+    private ServiceBusClient CreateServiceBusClient()
+    {
+        return new ServiceBusClient(
+            _options.Value.ServiceBusConnectionString,
+            new ServiceBusClientOptions
+            {
+                TransportType = _options.Value.TransportType,
+            });
+    }
 }

--- a/source/Messaging/source/Messaging/Internal/Subscriber/ServiceBusProcessorFactory.cs
+++ b/source/Messaging/source/Messaging/Internal/Subscriber/ServiceBusProcessorFactory.cs
@@ -31,7 +31,7 @@ internal sealed class ServiceBusProcessorFactory : IServiceBusProcessorFactory, 
 
     public ServiceBusProcessor CreateProcessor(string topicName, string subscriptionName)
     {
-        _serviceBusClient ??= new ServiceBusClient(_options.Value.ServiceBusConnectionString);
+        _serviceBusClient ??= CreateServiceBusClient();
         return _serviceBusClient.CreateProcessor(topicName, subscriptionName, new ServiceBusProcessorOptions
         {
             ReceiveMode = ServiceBusReceiveMode.PeekLock,
@@ -46,5 +46,15 @@ internal sealed class ServiceBusProcessorFactory : IServiceBusProcessorFactory, 
             await _serviceBusClient.DisposeAsync();
             _serviceBusClient = null;
         }
+    }
+
+    private ServiceBusClient CreateServiceBusClient()
+    {
+        return new ServiceBusClient(
+            _options.Value.ServiceBusConnectionString,
+            new ServiceBusClientOptions
+            {
+                TransportType = _options.Value.TransportType,
+            });
     }
 }

--- a/source/Messaging/source/Messaging/Messaging.csproj
+++ b/source/Messaging/source/Messaging/Messaging.csproj
@@ -34,7 +34,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Messaging</PackageId>
-    <PackageVersion>3.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.3.0$(VersionSuffix)</PackageVersion>
     <Title>Messaging library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Messaging/source/Messaging/Publisher/PublisherOptions.cs
+++ b/source/Messaging/source/Messaging/Publisher/PublisherOptions.cs
@@ -33,6 +33,7 @@ public sealed class PublisherOptions
 
     /// <summary>
     /// The type of protocol and transport that will be used for communicating with the Service Bus.
+    /// Default value is <see cref="ServiceBusTransportType.AmqpTcp"/>.
     /// </summary>
     public ServiceBusTransportType TransportType { get; set; } = ServiceBusTransportType.AmqpTcp;
 }

--- a/source/Messaging/source/Messaging/Publisher/PublisherOptions.cs
+++ b/source/Messaging/source/Messaging/Publisher/PublisherOptions.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Azure.Messaging.ServiceBus;
+
 namespace Energinet.DataHub.Core.Messaging.Communication.Publisher;
 
 /// <summary>
@@ -28,4 +30,9 @@ public sealed class PublisherOptions
     /// The name of the topic to send integration events to.
     /// </summary>
     public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The type of protocol and transport that will be used for communicating with the Service Bus.
+    /// </summary>
+    public ServiceBusTransportType TransportType { get; set; } = ServiceBusTransportType.AmqpTcp;
 }

--- a/source/Messaging/source/Messaging/Subscriber/SubscriberWorkerOptions.cs
+++ b/source/Messaging/source/Messaging/Subscriber/SubscriberWorkerOptions.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Azure.Messaging.ServiceBus;
+
 namespace Energinet.DataHub.Core.Messaging.Communication.Subscriber;
 
 /// <summary>
@@ -23,6 +25,11 @@ public sealed class SubscriberWorkerOptions
     /// The connection string for the Service Bus.
     /// </summary>
     public string ServiceBusConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The type of protocol and transport that will be used for communicating with the Service Bus.
+    /// </summary>
+    public ServiceBusTransportType TransportType { get; set; } = ServiceBusTransportType.AmqpTcp;
 
     /// <summary>
     /// The name of the topic from where to receive integration events.

--- a/source/Messaging/source/Messaging/Subscriber/SubscriberWorkerOptions.cs
+++ b/source/Messaging/source/Messaging/Subscriber/SubscriberWorkerOptions.cs
@@ -28,6 +28,7 @@ public sealed class SubscriberWorkerOptions
 
     /// <summary>
     /// The type of protocol and transport that will be used for communicating with the Service Bus.
+    /// Default value is <see cref="ServiceBusTransportType.AmqpTcp"/>.
     /// </summary>
     public ServiceBusTransportType TransportType { get; set; } = ServiceBusTransportType.AmqpTcp;
 


### PR DESCRIPTION
Allow setting TransportType for ServiceBus so we can get through firewall if AMQP ports are not open.