### PR TITLE
Expand eventhub resource with possibility to add consumer groups

### DIFF
--- a/source/TestCommon/documents/eventhubresourceprovider.md
+++ b/source/TestCommon/documents/eventhubresourceprovider.md
@@ -20,6 +20,10 @@ The fluent API chain always starts with a `BuildEventHub()` operation, and ends 
 
 The `CreateAsync()` operation returns the resource type `EventHubResource`. This type give us access to the full resource name created, and a producer client configured to send events to the created resource.
 
+### `AddConsumerGroup()`
+
+When building an EventHub its possible to add consumer groups.
+
 ### `Do()` and `SetEnvironmentVariableTo` extensions
 
 The `EventHubBuilder` type support the `Do()` operation which allows us to register *post actions*. Each post action will be called just after the event hub has been created, with the properties of the event hub.
@@ -42,9 +46,10 @@ var resourceProvider = new EventHubResourceProvider(
 Example 1 - creating an event hub:
 
 ```csharp
-// Create an event hub prefixed with the name "eventhub".
+// Create an event hub prefixed with the name "eventhub" and a consumergroup with name "consumer_group" (without optional user metadata).
 var eventHubResource = await resourceProvider
     .BuildEventHub("eventhub")
+    .AddConsumerGroup("consumer_group")
     .CreateAsync();
 
 // We can access the full event hub name...

--- a/source/TestCommon/documents/eventhubresourceprovider.md
+++ b/source/TestCommon/documents/eventhubresourceprovider.md
@@ -5,6 +5,7 @@ The `EventHubResourceProvider` and its related types, support us with the follow
 - The `EventHubResourceProvider` is the fluent API builder root. It automatically tracks and cleanup any resources created, when it is disposed.
 - The `EventHubResourceBuilder` type encapsulate the creation of an event hub in an existing Azure Event Hub namespace.
 - The `EventHubResource` type support lazy creation of a producer client.
+- The `EventHubConsumerGroupBuilder` type to encapsulate the creation of `ConsumerGroup`'s and adding to event hubs during creation of these.
 
 > For usage, see `EventHubResourceProviderTests` or [Aggregations](https://github.com/Energinet-DataHub/geh-aggregations) repository/domain.
 

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 4.6.0
+
+- Extended `EventHubResource` with possibility to add consumer groups
+
 ## Version 4.5.0
 
 - Added property `ApplicationInsightsConnectionString` to `IntegrationTestConfiguration` to support use of connection string when using Application Insights.

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/EventHub/ResourceProvider/EventHubResourceProviderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/EventHub/ResourceProvider/EventHubResourceProviderTests.cs
@@ -174,6 +174,30 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.EventH
                 var actualEnvironmentValue = Environment.GetEnvironmentVariable(environmentVariable);
                 actualEnvironmentValue.Should().Be(actualName);
             }
+
+            [Theory]
+            [InlineData("some user metadata")]
+            [InlineData(null)]
+            public async Task When_AddConsumerGroup_Then_CreatedEventHubHasConsumerGroup(string userMetadata)
+            {
+                // Arrange
+                var consumerGroupName = "consumer_group_name";
+
+                // Act
+                var actualResource = await Sut
+                    .BuildEventHub(NamePrefix)
+                    .AddConsumerGroup(consumerGroupName, userMetadata)
+                    .CreateAsync();
+
+                // Assert
+                using var response = await ResourceProviderFixture.ManagementClient.ConsumerGroups.GetWithHttpMessagesAsync(
+                    actualResource.ResourceGroup,
+                    actualResource.EventHubNamespace,
+                    actualResource.Name,
+                    consumerGroupName);
+                response.Body.Name.Should().Be(consumerGroupName);
+                response.Body.UserMetadata.Should().Be(userMetadata);
+            }
         }
     }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/EventHub/ResourceProvider/EventHubResourceProviderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/EventHub/ResourceProvider/EventHubResourceProviderTests.cs
@@ -24,6 +24,7 @@ using Energinet.DataHub.Core.TestCommon;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Extensions;
 using Energinet.DataHub.Core.TestCommon.Diagnostics;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.Azure.Management.EventHub.Models;
 using Xunit;
 
@@ -195,6 +196,8 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.EventH
                     actualResource.EventHubNamespace,
                     actualResource.Name,
                     consumerGroupName);
+
+                using var assertionScope = new AssertionScope();
                 response.Body.Name.Should().Be(consumerGroupName);
                 response.Body.UserMetadata.Should().Be(userMetadata);
             }

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/EventHub/ResourceProvider/EventHubResourceProviderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/EventHub/ResourceProvider/EventHubResourceProviderTests.cs
@@ -198,6 +198,27 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.EventH
                 response.Body.Name.Should().Be(consumerGroupName);
                 response.Body.UserMetadata.Should().Be(userMetadata);
             }
+
+            [Fact]
+            public async Task When_SetEnvironmentVariableToConsumerGroupName_Then_EnvironmentVariableContainsActualName()
+            {
+                // Arrange
+                var environmentVariable = "env_consumer_group_name";
+                var consumerGroupName = "consumer_group_name";
+
+                // Act
+                var actualResource = await Sut
+                    .BuildEventHub(NamePrefix)
+                    .AddConsumerGroup(consumerGroupName)
+                    .SetEnvironmentVariableToConsumerGroupName(environmentVariable)
+                    .CreateAsync();
+
+                // Assert
+                var actualName = actualResource.Name;
+
+                var actualEnvironmentValue = Environment.GetEnvironmentVariable(environmentVariable);
+                actualEnvironmentValue.Should().Be(consumerGroupName);
+            }
         }
     }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/EventHub/ResourceProvider/EventHubResourceProviderTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/EventHub/ResourceProvider/EventHubResourceProviderTests.cs
@@ -206,8 +206,8 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.EventH
             public async Task When_SetEnvironmentVariableToConsumerGroupName_Then_EnvironmentVariableContainsActualName()
             {
                 // Arrange
-                var environmentVariable = "env_consumer_group_name";
-                var consumerGroupName = "consumer_group_name";
+                const string environmentVariable = "env_consumer_group_name";
+                const string consumerGroupName = "consumer_group_name";
 
                 // Act
                 var actualResource = await Sut
@@ -217,8 +217,6 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Tests.Integration.EventH
                     .CreateAsync();
 
                 // Assert
-                var actualName = actualResource.Name;
-
                 var actualEnvironmentValue = Environment.GetEnvironmentVariable(environmentVariable);
                 actualEnvironmentValue.Should().Be(consumerGroupName);
             }

--- a/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubConsumerGroupBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubConsumerGroupBuilder.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvider;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvider;
+
+public class EventHubConsumerGroupBuilder : IEventHubResourceBuilder
+{
+    internal EventHubConsumerGroupBuilder(EventHubResourceBuilder eventHubResourceBuilder, string consumerGroupName, string? userMetadata = default)
+    {
+        EventHubResourceBuilder = eventHubResourceBuilder;
+        ConsumerGroupName = consumerGroupName;
+        UserMetadata = userMetadata;
+    }
+
+    internal string ConsumerGroupName { get; }
+
+    internal string? UserMetadata { get; }
+
+    private EventHubResourceBuilder EventHubResourceBuilder { get; }
+
+    /// <inheritdoc/>
+    public EventHubConsumerGroupBuilder AddConsumerGroup(string consumerGroupName, string? userMetaData = default)
+    {
+        return EventHubResourceBuilder.AddConsumerGroup(consumerGroupName, userMetaData);
+    }
+
+    /// <inheritdoc/>
+    public Task<EventHubResource> CreateAsync()
+    {
+        return EventHubResourceBuilder.CreateAsync();
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubConsumerGroupBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubConsumerGroupBuilder.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvider;
 
 namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvider;
 

--- a/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubConsumerGroupBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubConsumerGroupBuilder.cs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Azure.Management.EventHub.Models;
 
 namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvider;
 
@@ -23,13 +26,29 @@ public class EventHubConsumerGroupBuilder : IEventHubResourceBuilder
         EventHubResourceBuilder = eventHubResourceBuilder;
         ConsumerGroupName = consumerGroupName;
         UserMetadata = userMetadata;
+
+        PostActions = new List<Action<ConsumerGroup>>();
     }
 
     internal string ConsumerGroupName { get; }
 
     internal string? UserMetadata { get; }
 
+    internal IList<Action<ConsumerGroup>> PostActions { get; }
+
     private EventHubResourceBuilder EventHubResourceBuilder { get; }
+
+    /// <summary>
+    /// Add an action that will be called after the consumer group has been created.
+    /// </summary>
+    /// <param name="postAction">Action to call with consumer group name and metadata when it has been created.</param>
+    /// <returns>Consumer group builder.</returns>
+    public EventHubConsumerGroupBuilder Do(Action<ConsumerGroup> postAction)
+    {
+        PostActions.Add(postAction);
+
+        return this;
+    }
 
     /// <inheritdoc/>
     public EventHubConsumerGroupBuilder AddConsumerGroup(string consumerGroupName, string? userMetaData = default)

--- a/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubConsumerGroupBuilderExtensions.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubConsumerGroupBuilderExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvider;
+
+public static class EventHubConsumerGroupBuilderExtensions
+{
+    public static EventHubConsumerGroupBuilder SetEnvironmentVariableToConsumerGroupName(this EventHubConsumerGroupBuilder builder, string variable)
+    {
+        builder.Do(consumerGroup => Environment.SetEnvironmentVariable(variable, consumerGroup.Name));
+
+        return builder;
+    }
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubResource.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubResource.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Azure.Management.EventHub;
@@ -24,6 +26,7 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvide
     {
         private readonly Eventhub _properties;
         private readonly Lazy<EventHubProducerClient> _lazyProducerClient;
+        private readonly IList<ConsumerGroup> _consumerGroups;
 
         internal EventHubResource(EventHubResourceProvider resourceProvider, Eventhub properties)
         {
@@ -31,6 +34,9 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvide
 
             _properties = properties;
             _lazyProducerClient = new Lazy<EventHubProducerClient>(CreateProducerClient);
+            _consumerGroups = new List<ConsumerGroup>();
+
+            ConsumerGroups = new ReadOnlyCollection<ConsumerGroup>(_consumerGroups);
         }
 
         public string ResourceGroup => ResourceProvider.ResourceManagementSettings.ResourceGroup;
@@ -41,6 +47,8 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvide
 
         public EventHubProducerClient ProducerClient => _lazyProducerClient.Value;
 
+        public IReadOnlyCollection<ConsumerGroup>? ConsumerGroups { get; }
+
         public bool IsDisposed { get; private set; }
 
         private EventHubResourceProvider ResourceProvider { get; }
@@ -50,6 +58,11 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvide
             await DisposeAsyncCore()
                 .ConfigureAwait(false);
             GC.SuppressFinalize(this);
+        }
+
+        internal void AddConsumerGroup(ConsumerGroup consumerGroup)
+        {
+            _consumerGroups.Add(consumerGroup);
         }
 
         private EventHubProducerClient CreateProducerClient()

--- a/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubResourceBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubResourceBuilder.cs
@@ -123,6 +123,11 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvide
                     .ConfigureAwait(false);
 
                 eventHubResource.AddConsumerGroup(createdConsumerGroup);
+
+                foreach (var postAction in consumerGroupBuilderPair.Value.PostActions)
+                {
+                    postAction(createdConsumerGroup);
+                }
             }
         }
     }

--- a/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubResourceBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/EventHubResourceBuilder.cs
@@ -106,11 +106,14 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvide
 
         private async Task CreateConsumerGroupsAsync(EventHubResource eventHubResource)
         {
+            var managementClient = await ResourceProvider.LazyManagementClient
+                .ConfigureAwait(false);
+
             foreach (var consumerGroupBuilderPair in ConsumerGroupBuilders)
             {
                 var consumerGroup = consumerGroupBuilderPair.Value;
 
-                var createdConsumerGroup = await (await ResourceProvider.LazyManagementClient).ConsumerGroups
+                var createdConsumerGroup = await managementClient.ConsumerGroups
                     .CreateOrUpdateAsync(
                         ResourceProvider.ResourceManagementSettings.ResourceGroup,
                         ResourceProvider.EventHubNamespace,

--- a/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/IEventHubResourceBuilder.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/EventHub/ResourceProvider/IEventHubResourceBuilder.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+
+namespace Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvider;
+
+/// <summary>
+/// Part of fluent API for creating an Event Hub with consumer groups.
+/// </summary>
+public interface IEventHubResourceBuilder
+{
+    /// <summary>
+    /// Add a Consumer Group to the Event Hub being created.
+    /// </summary>
+    /// <param name="consumerGroupName">Name of consumer group to add.</param>
+    /// <param name="userMetaData">Metadata for consumer group to add (optional).</param>
+    /// <returns>EventHub consumer group builder.</returns>
+    EventHubConsumerGroupBuilder AddConsumerGroup(string consumerGroupName, string? userMetaData = default);
+
+    /// <summary>
+    /// Create event hub according to configured builder.
+    /// </summary>
+    /// <returns>Instance with information about the created event hub.</returns>
+    Task<EventHubResource> CreateAsync();
+}

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>4.5.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.6.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>4.5.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.6.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Expanding the `EventHubResource` with possibility to add consumer groups. Based on the same builder pattern as adding subscriptions to the ServiceBus `TopicResource`.

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
