### PR TITLE
fix: Replace bogus Databricks SQL execution time out implementation with cancellation tokens

### DIFF
--- a/source/Databricks/documents/documentation.md
+++ b/source/Databricks/documents/documentation.md
@@ -8,7 +8,7 @@ The implementation uses solely `disposition=EXTERNAL_LINKS` despite that inlinin
 
 ### Usage
 
-Install `Energinet.DataHub.Core.Databricks.SqlStatementExecution` package.~~~~
+Install `Energinet.DataHub.Core.Databricks.SqlStatementExecution` package.
 
 Example of how to setup the Databricks Sql Statement Execution in `startup.cs`.
 

--- a/source/Databricks/documents/documentation.md
+++ b/source/Databricks/documents/documentation.md
@@ -8,7 +8,7 @@ The implementation uses solely `disposition=EXTERNAL_LINKS` despite that inlinin
 
 ### Usage
 
-Install `Energinet.DataHub.Core.Databricks.SqlStatementExecution` package.
+Install `Energinet.DataHub.Core.Databricks.SqlStatementExecution` package.~~~~
 
 Example of how to setup the Databricks Sql Statement Execution in `startup.cs`.
 

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -6,6 +6,8 @@ The `DatabricksSqlStatementOptions.TimeoutInSeconds` is removed. It didn't repre
 but rather constituted a part of the overall time out where the rest of the timeout was hardcoded.
 So it was misleading. It has been replaced by the usage of cancellation tokens.
 
+There are no changes to the jobs API.
+
 ## Version 8.2.1
 
 - No functional change

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,11 @@
 # Databricks Release Notes
 
+## Version 9.0.0
+
+The `DatabricksSqlStatementOptions.TimeoutInSeconds` is removed. It didn't represent the total timeout for a request,
+but rather constituted a part of the overall time out where the rest of the timeout was hardcoded.
+So it was misleading. It has been replaced by the usage of cancellation tokens.
+
 ## Version 8.2.1
 
 - No functional change

--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-    <PackageVersion>8.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>9.0.0$(VersionSuffix)</PackageVersion>
     <Title>Databricks Jobs</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/DatabricksStatementsTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/DatabricksStatementsTests.cs
@@ -161,7 +161,7 @@ public class DatabricksStatementsTests : IClassFixture<DatabricksSqlWarehouseFix
         cts.CancelAfter(TimeSpan.FromSeconds(1));
 
         // Act
-        var result = client.ExecuteStatementAsync(statement, format, new Configuration(Timeout: 30, loopDelay: 10), cts.Token);
+        var result = client.ExecuteStatementAsync(statement, format, initialTimeout: 30, loopDelay: 10, cts.Token);
         var rowCount = await result.CountAsync();
 
         // Assert

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/Statements/AtLeast10SecStatement.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/Statements/AtLeast10SecStatement.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.IntegrationTests.Client.Statements;
+
+/// <summary>
+/// Produces 1.000.000 rows
+/// </summary>
+public class AtLeast10SecStatement : DatabricksStatement
+{
+    protected internal override string GetSqlStatement()
+    {
+        return "SELECT concat_ws('-', M.id, N.id, random()) as ID FROM range(1000000) AS M, range(1000000) AS N";
+    }
+}

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/AppSettings/DatabricksSqlStatementOptionsTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/AppSettings/DatabricksSqlStatementOptionsTests.cs
@@ -19,7 +19,7 @@ namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.AppS
 public class DatabricksSqlStatementOptionsTests
 {
     [Theory]
-    [InlineAutoMoqData(typeof(DatabricksSqlStatementOptions), 6, "WorkspaceUrl", "WorkspaceToken", "WarehouseId", "TimeoutInSeconds", "DatabricksHealthCheckStartHour", "DatabricksHealthCheckEndHour")]
+    [InlineAutoMoqData(typeof(DatabricksSqlStatementOptions), 5, "WorkspaceUrl", "WorkspaceToken", "WarehouseId", "DatabricksHealthCheckStartHour", "DatabricksHealthCheckEndHour")]
     public void Options_HaveTheCorrectSettingNamesAndNumberOfSettings(Type sut, int settingsCount, params string[] expectedNames)
     {
         // Arrange & Act

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/Exceptions/DatabricksExceptionTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/Exceptions/DatabricksExceptionTests.cs
@@ -29,7 +29,7 @@ public class DatabricksExceptionTests
     {
         // Arrange
         const string message = "foo";
-        var databricksStatementRequest = new DatabricksStatementRequest(1, "2", statement, Format.ApacheArrow.Value);
+        var databricksStatementRequest = new DatabricksStatementRequest("2", statement, Format.ApacheArrow.Value);
         var response = new DatabricksStatementResponse();
 
         // Act

--- a/source/Databricks/source/SqlStatementExecution.UnitTests/Fixtures/HealthChecksFixture.cs
+++ b/source/Databricks/source/SqlStatementExecution.UnitTests/Fixtures/HealthChecksFixture.cs
@@ -55,7 +55,6 @@ namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.UnitTests.Fixt
                         options.WarehouseId = "baz";
                         options.WorkspaceToken = "bar";
                         options.WorkspaceUrl = "https://foo.com";
-                        options.TimeoutInSeconds = 5;
                         options.DatabricksHealthCheckStartHour = 0;
                         options.DatabricksHealthCheckEndHour = 23;
                     });

--- a/source/Databricks/source/SqlStatementExecution/DatabricksSqlStatementOptions.cs
+++ b/source/Databricks/source/SqlStatementExecution/DatabricksSqlStatementOptions.cs
@@ -42,12 +42,6 @@ public class DatabricksSqlStatementOptions
     public string WarehouseId { get; set; } = string.Empty;
 
     /// <summary>
-    /// Seconds we allow the Databricks Statement Execution Api to respond.
-    /// </summary>
-    [Required]
-    public int TimeoutInSeconds { get; set; } = 30;
-
-    /// <summary>
     /// Defines the hour of the day when the health check DataLake should start.
     /// The default value is 6:00 AM.
     /// </summary>

--- a/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
+++ b/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
@@ -150,7 +150,7 @@ public class DatabricksSqlWarehouseQueryExecutor
         }
     }
 
-    internal async IAsyncEnumerable<dynamic> DoExecuteStatementAsync(
+    private async IAsyncEnumerable<dynamic> DoExecuteStatementAsync(
         DatabricksStatement statement,
         Format format,
         [EnumeratorCancellation]CancellationToken cancellationToken)

--- a/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
+++ b/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
@@ -56,7 +56,9 @@ public class DatabricksSqlWarehouseQueryExecutor
     /// Asynchronously executes a parameterized SQL query on Databricks and streams the results using <see cref="Format.ApacheArrow"/> format.
     /// </summary>
     /// <param name="statement">The SQL query to be executed, with collection of <see cref="QueryParameter"/> parameters.</param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used by other object or threads to receive notice of cancellation.
+    /// The cancellation token can be used to implement time out as well.</param>
     /// <returns>
     /// An asynchronous enumerable of <see cref="ExpandoObject"/> object representing the result of the query.
     /// </returns>
@@ -77,7 +79,9 @@ public class DatabricksSqlWarehouseQueryExecutor
     /// </summary>
     /// <param name="statement">The SQL query to be executed, with collection of <see cref="QueryParameter"/> parameters.</param>
     /// <param name="format">The desired format of the data returned.</param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used by other object or threads to receive notice of cancellation.
+    /// The cancellation token can be used to implement time out as well.</param>
     /// <returns>
     /// An asynchronous enumerable of <see cref="ExpandoObject"/> object representing the result of the query.
     /// </returns>
@@ -103,7 +107,9 @@ public class DatabricksSqlWarehouseQueryExecutor
     /// Asynchronously executes a parameterized SQL query on Databricks and streams the result back as a collection of strongly typed objects.
     /// </summary>
     /// <param name="statement">The SQL query to be executed, with collection of <see cref="QueryParameter"/> parameters.</param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used by other object or threads to receive notice of cancellation.
+    /// The cancellation token can be used to implement time out as well.</param>
     /// <typeparam name="T">Target type</typeparam>
     /// <returns>An asynchronous enumerable of <typeparamref name="T"/> representing the result of the query.</returns>
     /// <remarks>

--- a/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
+++ b/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
@@ -70,7 +70,7 @@ public class DatabricksSqlWarehouseQueryExecutor
     /// </remarks>
     public virtual IAsyncEnumerable<dynamic> ExecuteStatementAsync(
         DatabricksStatement statement,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
         => ExecuteStatementAsync(statement, Format.ApacheArrow, cancellationToken);
 
     /// <summary>
@@ -92,7 +92,7 @@ public class DatabricksSqlWarehouseQueryExecutor
     public virtual async IAsyncEnumerable<dynamic> ExecuteStatementAsync(
         DatabricksStatement statement,
         Format format,
-        [EnumeratorCancellation]CancellationToken cancellationToken = default)
+        [EnumeratorCancellation]CancellationToken cancellationToken)
     {
         await foreach (var record in DoExecuteStatementAsync(statement, format, cancellationToken))
         {
@@ -104,6 +104,7 @@ public class DatabricksSqlWarehouseQueryExecutor
     /// Asynchronously executes a parameterized SQL query on Databricks and streams the result back as a collection of strongly typed objects.
     /// </summary>
     /// <param name="statement">The SQL query to be executed, with collection of <see cref="QueryParameter"/> parameters.</param>
+    /// <param name="cancellationToken"></param>
     /// <typeparam name="T">Target type</typeparam>
     /// <returns>An asynchronous enumerable of <typeparamref name="T"/> representing the result of the query.</returns>
     /// <remarks>
@@ -115,12 +116,14 @@ public class DatabricksSqlWarehouseQueryExecutor
     /// - Must only have a single constructor<br/>
     /// - Must be annotated with <see cref="ArrowFieldAttribute"/> to indicate the order of the constructor parameters
     /// </remarks>
-    public virtual async IAsyncEnumerable<T> ExecuteStatementAsync<T>(DatabricksStatement statement)
+    public virtual async IAsyncEnumerable<T> ExecuteStatementAsync<T>(
+        DatabricksStatement statement,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
         where T : class
     {
         var strategy = new StronglyTypedApacheArrowFormat(_options);
-        var request = strategy.GetStatementRequest(statement);
-        var response = await request.WaitForSqlWarehouseResultAsync(_httpClient, StatementsEndpointPath);
+        var request = strategy.GetStatementRequest(statement, );
+        var response = await request.WaitForSqlWarehouseResultAsync(_httpClient, StatementsEndpointPath, cancellationToken);
 
         if (_httpClient.BaseAddress == null) throw new InvalidOperationException();
 

--- a/source/Databricks/source/SqlStatementExecution/Formats/JsonArrayFormat.cs
+++ b/source/Databricks/source/SqlStatementExecution/Formats/JsonArrayFormat.cs
@@ -15,7 +15,9 @@
 using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Threading;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Statement;
 
 namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Formats;
@@ -30,9 +32,9 @@ internal class JsonArrayFormat : IExecuteStrategy
     }
 
     public DatabricksStatementRequest GetStatementRequest(DatabricksStatement statement)
-        => new(_options.TimeoutInSeconds, _options.WarehouseId, statement, DatabricksStatementRequest.JsonFormat);
+        => new(_options.WarehouseId, statement, DatabricksStatementRequest.JsonFormat);
 
-    public async IAsyncEnumerable<dynamic> ExecuteAsync(Stream content, DatabricksStatementResponse response)
+    public async IAsyncEnumerable<dynamic> ExecuteAsync(Stream content, DatabricksStatementResponse response, [EnumeratorCancellation]CancellationToken cancellationToken)
     {
         await foreach (var record in JsonSerializer.DeserializeAsyncEnumerable<string[]>(content))
         {

--- a/source/Databricks/source/SqlStatementExecution/Formats/JsonArrayFormat.cs
+++ b/source/Databricks/source/SqlStatementExecution/Formats/JsonArrayFormat.cs
@@ -34,9 +34,14 @@ internal class JsonArrayFormat : IExecuteStrategy
     public DatabricksStatementRequest GetStatementRequest(DatabricksStatement statement)
         => new(_options.WarehouseId, statement, DatabricksStatementRequest.JsonFormat);
 
-    public async IAsyncEnumerable<dynamic> ExecuteAsync(Stream content, DatabricksStatementResponse response, [EnumeratorCancellation]CancellationToken cancellationToken)
+    public async IAsyncEnumerable<dynamic> ExecuteAsync(
+        Stream content,
+        DatabricksStatementResponse response,
+        [EnumeratorCancellation]CancellationToken cancellationToken)
     {
-        await foreach (var record in JsonSerializer.DeserializeAsyncEnumerable<string[]>(content))
+        await foreach (var record in JsonSerializer.DeserializeAsyncEnumerable<string[]>(
+                           content,
+                           cancellationToken: cancellationToken))
         {
             if (record == null) continue;
 

--- a/source/Databricks/source/SqlStatementExecution/IExecuteStrategy.cs
+++ b/source/Databricks/source/SqlStatementExecution/IExecuteStrategy.cs
@@ -14,6 +14,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Statement;
 
 namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution;
@@ -35,6 +36,7 @@ internal interface IExecuteStrategy
     /// </summary>
     /// <param name="content"></param>
     /// <param name="response"></param>
-    /// <returns>IAsyncEnumerable&lt;dynamic&gt;</returns>
-    IAsyncEnumerable<dynamic> ExecuteAsync(Stream content, DatabricksStatementResponse response);
+    /// <param name="cancellationToken"></param>
+    /// <returns><see cref="IAsyncEnumerable{T}"/></returns>
+    IAsyncEnumerable<dynamic> ExecuteAsync(Stream content, DatabricksStatementResponse response, CancellationToken cancellationToken);
 }

--- a/source/Databricks/source/SqlStatementExecution/IExecuteStrategy.cs
+++ b/source/Databricks/source/SqlStatementExecution/IExecuteStrategy.cs
@@ -38,5 +38,8 @@ internal interface IExecuteStrategy
     /// <param name="response"></param>
     /// <param name="cancellationToken"></param>
     /// <returns><see cref="IAsyncEnumerable{T}"/></returns>
-    IAsyncEnumerable<dynamic> ExecuteAsync(Stream content, DatabricksStatementResponse response, CancellationToken cancellationToken);
+    IAsyncEnumerable<dynamic> ExecuteAsync(
+        Stream content,
+        DatabricksStatementResponse response,
+        CancellationToken cancellationToken);
 }

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>8.2.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>9.0.0$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
+++ b/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
@@ -23,6 +23,10 @@ using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 
 namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.Statement;
 
+/// <summary>
+/// Some properties are being serialized and passed to the Databricks SQL Statement Execution API.
+/// Learn more about the API here: https://docs.databricks.com/api/azure/workspace/statementexecution.
+/// </summary>
 internal class DatabricksStatementRequest
 {
     internal const string JsonFormat = "JSON_ARRAY";

--- a/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
+++ b/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
@@ -62,11 +62,6 @@ internal class DatabricksStatementRequest
     [JsonPropertyName("wait_timeout")]
     public string WaitTimeout { get; init; }
 
-    /// <summary>
-    /// Controls the delay between each call to the Databricks API to check for the result availability.
-    /// </summary>
-    public TimeSpan LoopDelay { get; }
-
     [JsonPropertyName("format")]
     public string Format { get; set; }
 
@@ -98,7 +93,7 @@ internal class DatabricksStatementRequest
         }
         else
         {
-            await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
 
             var path = $"{endpoint}/{response.statement_id}";
             using var httpResponse = await client.GetAsync(path, cancellationToken);

--- a/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
+++ b/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Exceptions;
 
@@ -26,13 +27,13 @@ internal class DatabricksStatementRequest
     internal const string JsonFormat = "JSON_ARRAY";
     internal const string ArrowFormat = "ARROW_STREAM";
 
-    internal DatabricksStatementRequest(int timeoutInSeconds, string warehouseId, DatabricksStatement statement, string format)
+    internal DatabricksStatementRequest(string warehouseId, DatabricksStatement statement, string format)
     {
         Statement = statement.GetSqlStatement();
         Parameters = statement.GetParameters().ToArray();
         WarehouseId = warehouseId;
         Disposition = "EXTERNAL_LINKS";
-        WaitTimeout = $"{timeoutInSeconds}s";
+        WaitTimeout = "30s";
         Format = format;
     }
 
@@ -48,22 +49,26 @@ internal class DatabricksStatementRequest
     [JsonPropertyName("disposition")]
     public string Disposition { get; init; }
 
+    /// <summary>
+    /// Solely used to set the timeout for the first Databricks API invocation.
+    /// If the result wasn't included then the <see cref="DatabricksStatementRequest"/> will repeatedly
+    /// check for the result until it's available.
+    /// </summary>
     [JsonPropertyName("wait_timeout")]
-    public string WaitTimeout { get; init; }
+    public string WaitTimeout { get; }
 
     [JsonPropertyName("format")]
     public string Format { get; set; }
 
-    public async ValueTask<DatabricksStatementResponse> WaitForSqlWarehouseResultAsync(HttpClient client, string endpoint)
+    public async ValueTask<DatabricksStatementResponse> WaitForSqlWarehouseResultAsync(HttpClient client, string endpoint, CancellationToken cancellationToken = default)
     {
         DatabricksStatementResponse? response = null;
-        var retriesLeft = 10;
         do
         {
-            response = await GetResponseFromDataWarehouseAsync(client, endpoint, response);
+            response = await GetResponseFromDataWarehouseAsync(client, endpoint, response, cancellationToken);
             if (response.IsSucceeded) return response;
         }
-        while ((response.IsPending || response.IsRunning) && retriesLeft-- > 0);
+        while (response.IsPending || response.IsRunning);
 
         throw new DatabricksException("Unable to fetch result from Databricks", this, response);
     }
@@ -71,7 +76,8 @@ internal class DatabricksStatementRequest
     private async Task<DatabricksStatementResponse> GetResponseFromDataWarehouseAsync(
         HttpClient client,
         string endpoint,
-        DatabricksStatementResponse? response)
+        DatabricksStatementResponse? response,
+        CancellationToken cancellationToken)
     {
         if (response == null)
         {
@@ -80,7 +86,7 @@ internal class DatabricksStatementRequest
         }
         else
         {
-            await Task.Delay(10);
+            await Task.Delay(10, cancellationToken); // Wait for a short time before checking for the result again
             var path = $"{endpoint}/{response.statement_id}";
             using var httpResponse = await client.GetAsync(path);
             response = await httpResponse.Content.ReadFromJsonAsync<DatabricksStatementResponse>();

--- a/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
+++ b/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
@@ -28,20 +28,14 @@ internal class DatabricksStatementRequest
     internal const string JsonFormat = "JSON_ARRAY";
     internal const string ArrowFormat = "ARROW_STREAM";
 
-    internal DatabricksStatementRequest(string warehouseId, DatabricksStatement statement, string format, TimeSpan initialTimeout, TimeSpan loopDelay)
+    internal DatabricksStatementRequest(string warehouseId, DatabricksStatement statement, string format)
     {
         Statement = statement.GetSqlStatement();
         Parameters = statement.GetParameters().ToArray();
         WarehouseId = warehouseId;
         Disposition = "EXTERNAL_LINKS";
-        WaitTimeout = $"{initialTimeout.TotalSeconds}s";
+        WaitTimeout = "30s";
         Format = format;
-        LoopDelay = loopDelay;
-    }
-
-    internal DatabricksStatementRequest(string warehouseId, DatabricksStatement statement, string format)
-        : this(warehouseId, statement, format, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(10))
-    {
     }
 
     [JsonPropertyName("parameters")]

--- a/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
+++ b/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
@@ -108,7 +108,9 @@ internal class DatabricksStatementRequest
         }
 
         if (response == null)
+        {
             throw new DatabricksException("Unable to fetch result from Databricks", this);
+        }
 
         return response;
     }


### PR DESCRIPTION
## Description

Replace bogus Databricks SQL execution time-out implementation with the best practice and much more flexible usage of cancellation tokens.

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
