### PR TITLE
fix: Add try-catch in health checks

### DIFF
--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Databricks Release Notes
 
+## Version 9.0.1
+
+Added try-catch block to health checks to prevent both logging exceptions and indicate unhealthy state.
+
 ## Version 9.0.0
 
 The `DatabricksSqlStatementOptions.TimeoutInSeconds` is removed. It didn't represent the total timeout for a request,

--- a/source/Databricks/source/Jobs/Diagnostics/HealthChecks/DatabricksJobsApiHealthCheck.cs
+++ b/source/Databricks/source/Jobs/Diagnostics/HealthChecks/DatabricksJobsApiHealthCheck.cs
@@ -48,7 +48,14 @@ public class DatabricksJobsApiHealthCheck : IHealthCheck
         if (_options.DatabricksHealthCheckStartHour <= currentHour
             && currentHour <= _options.DatabricksHealthCheckEndHour)
         {
-            await _jobsApiClient.Jobs.List(1, 0, null, false, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _jobsApiClient.Jobs.List(1, 0, null, false, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy("Databricks Jobs API is unhealthy", ex);
+            }
         }
 
         return HealthCheckResult.Healthy();

--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-    <PackageVersion>9.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>9.0.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks Jobs</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/Diagnostics/HealthChecks/DatabricksSqlStatementApiHealthCheck.cs
+++ b/source/Databricks/source/SqlStatementExecution/Diagnostics/HealthChecks/DatabricksSqlStatementApiHealthCheck.cs
@@ -50,13 +50,20 @@ public class DatabricksSqlStatementApiHealthCheck : IHealthCheck
         var currentHour = _clock.GetCurrentInstant().ToDateTimeUtc().Hour;
         if (_options.DatabricksHealthCheckStartHour <= currentHour && currentHour <= _options.DatabricksHealthCheckEndHour)
         {
-            var httpClient = CreateHttpClient();
-            var url = $"{_options.WorkspaceUrl}/api/2.0/sql/warehouses/{_options.WarehouseId}";
-            var response = await httpClient
-                .GetAsync(url, cancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                var httpClient = CreateHttpClient();
+                var url = $"{_options.WorkspaceUrl}/api/2.0/sql/warehouses/{_options.WarehouseId}";
+                var response = await httpClient
+                    .GetAsync(url, cancellationToken)
+                    .ConfigureAwait(false);
 
-            return response.IsSuccessStatusCode ? HealthCheckResult.Healthy() : HealthCheckResult.Unhealthy();
+                return response.IsSuccessStatusCode ? HealthCheckResult.Healthy() : HealthCheckResult.Unhealthy();
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy("Databricks Sql Statement Execution API is unhealthy", ex);
+            }
         }
 
         return HealthCheckResult.Healthy();

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>9.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>9.0.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Add try-catch in health checks to avoid reporting both unhealthy states and logging exceptions.

The wholesale subsystem is experiencing transient exceptions, which don't render the application unhealthy but cause a lot of operations noise. This PR removes or reduces the noise, but is not a replacement for looking into the transient exceptions.

## Quality

- [ ] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [ ] Public types and methods are documented
- [ ] Tests are implemented and executed locally
