### PR TITLE
Cancel statement if token cancellation is requested

### DIFF
--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,11 @@
 # Databricks Release Notes
 
+## Version 9.0.2
+
+Cancel statement if token cancellation is requested.
+
+When the request is canceled the cluster is notified to also cancel execution of that statement.
+
 ## Version 9.0.1
 
 Added try-catch block to health checks to prevent both logging exceptions and indicate unhealthy state.

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -6,6 +6,8 @@ Cancel statement if token cancellation is requested.
 
 When the request is canceled the cluster is notified to also cancel execution of that statement.
 
+With this change the communication with the job cluster is using the [**Asynchronous mode**](https://docs.databricks.com/api/azure/workspace/statementexecution/executestatement#wait_timeout).
+
 ## Version 9.0.1
 
 Added try-catch block to health checks to prevent both logging exceptions and indicate unhealthy state.

--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-    <PackageVersion>9.0.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>9.0.2$(VersionSuffix)</PackageVersion>
     <Title>Databricks Jobs</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/DatabricksStatementsTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/DatabricksStatementsTests.cs
@@ -171,7 +171,7 @@ public class DatabricksStatementsTests : IClassFixture<DatabricksSqlWarehouseFix
     }
 
     [Fact]
-    public async Task Given_Cancellation_Token_When_Token_Is_Cancelled_Then_Cluster_Job_Is_Cancelled()
+    public async Task GivenCancellationToken_WhenTokenIsCancelled_ThenClusterJobIsCancelled()
     {
         var client = _sqlWarehouseFixture.CreateSqlStatementClient();
         var statement = new AtLeast10SecStatement();
@@ -185,7 +185,7 @@ public class DatabricksStatementsTests : IClassFixture<DatabricksSqlWarehouseFix
             _ = await result.CountAsync(cts.Token);
         });
 
-        await AssertThatStatementIsCancelled(_sqlWarehouseFixture.CreateHttpClient(), statement.HelperId.ToString());
+        await AssertThatStatementIsCancelledAsync(_sqlWarehouseFixture.CreateHttpClient(), statement.HelperId.ToString());
     }
 
     public static IEnumerable<object[]> GetFormats()
@@ -218,7 +218,7 @@ public class DatabricksStatementsTests : IClassFixture<DatabricksSqlWarehouseFix
         public string QueryText { get; init; } = string.Empty;
     }
 
-    private static async Task AssertThatStatementIsCancelled(HttpClient client, string statementId)
+    private static async Task AssertThatStatementIsCancelledAsync(HttpClient client, string statementId)
     {
         var retriesLeft = 6;
         while (retriesLeft-- > 0)

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/Statements/AtLeast10SecStatement.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/Statements/AtLeast10SecStatement.cs
@@ -19,8 +19,15 @@ namespace Energinet.DataHub.Core.Databricks.SqlStatementExecution.IntegrationTes
 /// </summary>
 public class AtLeast10SecStatement : DatabricksStatement
 {
+    public AtLeast10SecStatement()
+    {
+        HelperId = Guid.NewGuid();
+    }
+
+    public Guid HelperId { get; private set; }
+
     protected internal override string GetSqlStatement()
     {
-        return "SELECT concat_ws('-', M.id, N.id, random()) as ID FROM range(1000000) AS M, range(1000000) AS N";
+        return $"SELECT concat_ws('-', M.id, N.id, random()) as ID FROM range(1000000) AS M, range(1000000) AS N; --HelperId:{HelperId}";
     }
 }

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Fixtures/DatabricksSqlWarehouseFixture.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Fixtures/DatabricksSqlWarehouseFixture.cs
@@ -29,6 +29,15 @@ public sealed class DatabricksSqlWarehouseFixture
         return serviceProvider.GetRequiredService<DatabricksSqlWarehouseQueryExecutor>();
     }
 
+    public HttpClient CreateHttpClient()
+    {
+        var services = CreateServiceCollection();
+        var serviceProvider = services.BuildServiceProvider();
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+        return factory.CreateClient("Databricks");
+    }
+
     private static ServiceCollection CreateServiceCollection()
     {
         var integrationTestConfiguration = _lazyConfiguration.Value;

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>9.0.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>9.0.2$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
+++ b/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
@@ -93,6 +93,7 @@ internal class DatabricksStatementRequest
         if (response == null)
         {
             // No cancellation token is used because we want to wait for the result
+            // With the response we are able to cancel the statement if needed
             using var httpResponse = await client.PostAsJsonAsync(endpoint, this);
             response = await httpResponse.Content.ReadFromJsonAsync<DatabricksStatementResponse>();
         }

--- a/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
+++ b/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
@@ -80,12 +80,13 @@ internal class DatabricksStatementRequest
                     if (string.IsNullOrEmpty(response.statement_id)) throw new InvalidOperationException("The statement_id is missing from databricks response");
 
                     // Cancel the statement without cancellation token since it is already cancelled
-                    await CancelStatementAsync(client, endpoint, response.statement_id); 
+                    await CancelStatementAsync(client, endpoint, response.statement_id);
                     cancellationToken.ThrowIfCancellationRequested();
                 }
             }
             catch (TaskCanceledException tce)
             {
+                if (!string.IsNullOrEmpty(response?.statement_id)) await CancelStatementAsync(client, endpoint, response.statement_id);
                 throw new OperationCanceledException("The operation was cancelled", tce, cancellationToken);
             }
         }
@@ -128,6 +129,5 @@ internal class DatabricksStatementRequest
     {
         var path = $"{endpoint}/{statementId}/cancel";
         using var httpResponse = await client.PostAsync(path, new StringContent(string.Empty));
-        httpResponse.EnsureSuccessStatusCode();
     }
 }

--- a/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
+++ b/source/Databricks/source/SqlStatementExecution/Statement/DatabricksStatementRequest.cs
@@ -75,11 +75,14 @@ internal class DatabricksStatementRequest
                 response = await GetResponseFromDataWarehouseAsync(client, endpoint, response, cancellationToken);
                 if (response.IsSucceeded) return response;
 
-                if (cancellationToken.IsCancellationRequested == false) continue;
-                if (string.IsNullOrEmpty(response.statement_id)) throw new InvalidOperationException("The statement_id is missing from databricks response");
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    if (string.IsNullOrEmpty(response.statement_id)) throw new InvalidOperationException("The statement_id is missing from databricks response");
 
-                await CancelStatementAsync(client, endpoint, response.statement_id); // Cancel the statement without cancellation token since it is already cancelled
-                cancellationToken.ThrowIfCancellationRequested();
+                    // Cancel the statement without cancellation token since it is already cancelled
+                    await CancelStatementAsync(client, endpoint, response.statement_id); 
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
             }
             catch (TaskCanceledException tce)
             {


### PR DESCRIPTION
## Description

With the introduction of `CancellationToken` it is possible to cancel a statement that is sent to a Databricks cluster.

If a request is cancelled with a token then the statement continues to execute on the cluster. This PR sends a cancellation request to the cluster for the current statement.

Input needed:
How can this be tested? I have not be able to find a good way to test it.

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
