### PR TITLE
Downgrade az cli version

### DIFF
--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
     environment: AzureAuth
 
-    # We need to have permissions here to be able to support manually triggering this workflow for releasing a pre-release.
+    # We need to have permissions here to be able to support manually triggering this workflow for releasing a pre-release
     permissions:
       id-token: write # Needed by 'dotnet-solution-build-and-test' to login to Azure
       contents: read # Needed by https://github.com/EnricoMi/publish-unit-test-result-action

--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -61,12 +61,12 @@ jobs:
         uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@v13
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@dstenroejl/az-cli-bug # TODO: Revert to v13
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@v13
         with:
           use_azure_functions_tools: "true"
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@v13
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@dstenroejl/az-cli-bug # TODO: Revert to v13
         with:
           solution_file_path: ./source/TestCommon/TestCommon.sln
           azure_tenant_id: ${{ vars.integration_test_azure_tenant_id }}

--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -66,7 +66,7 @@ jobs:
           use_azure_functions_tools: "true"
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@dstenroejl/az-cli-bug # TODO: Revert to v13
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@dstenroejl/az-cli-bug # TODO: Revert to v13 when done
         with:
           solution_file_path: ./source/TestCommon/TestCommon.sln
           azure_tenant_id: ${{ vars.integration_test_azure_tenant_id }}

--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -66,7 +66,7 @@ jobs:
           use_azure_functions_tools: "true"
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@dstenroejl/az-cli-bug # TODO: Revert to v13 when done
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@dstenroejl/az-cli-bug # TODO: Revert to v13 when done, tet once more
         with:
           solution_file_path: ./source/TestCommon/TestCommon.sln
           azure_tenant_id: ${{ vars.integration_test_azure_tenant_id }}

--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
     environment: AzureAuth
 
-    # We need to have permissions here to be able to support manually triggering this workflow for releasing a pre-release
+    # We need to have permissions here to be able to support manually triggering this workflow for releasing a pre-release.
     permissions:
       id-token: write # Needed by 'dotnet-solution-build-and-test' to login to Azure
       contents: read # Needed by https://github.com/EnricoMi/publish-unit-test-result-action
@@ -66,7 +66,7 @@ jobs:
           use_azure_functions_tools: "true"
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@dstenroejl/az-cli-bug # TODO: Revert to v13 when done, tet once more
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@v13
         with:
           solution_file_path: ./source/TestCommon/TestCommon.sln
           azure_tenant_id: ${{ vars.integration_test_azure_tenant_id }}

--- a/.github/workflows/testcommon-bundle-publish.yml
+++ b/.github/workflows/testcommon-bundle-publish.yml
@@ -61,7 +61,7 @@ jobs:
         uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@v13
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@v13
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@dstenroejl/az-cli-bug # TODO: Revert to v13
         with:
           use_azure_functions_tools: "true"
 

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Fixtures/AzuriteManagerFixture.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Fixtures/AzuriteManagerFixture.cs
@@ -30,10 +30,7 @@ public sealed class AzuriteManagerFixture : IDisposable
 
     public void Dispose()
     {
-        if (AzuriteManager != null)
-        {
-            AzuriteManager.Dispose();
-        }
+        AzuriteManager?.Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

⚠️ To force an update and release TestCommon, we have made a small change in the publishing workflow. Version 5.1.0 was never released, which is shy we don't need to update release notes and version.

It seems there is a bug i az cli v2.59.0 so we will try to downgrade to v2.58.0 (is handled in the reusable action)

See https://github.com/Azure/login/issues/372#issuecomment-2056289617

## Quality

- [ ] Documentation is updated
- [ ] Release notes are updated
- [ ] Package version is updated
- [ ] Public types and methods are documented
- [ ] Tests are implemented and executed locally
