### PR TITLE
Update logger to use message template and not string-interpolation.

### DIFF
--- a/source/App/source/ExampleHost.WebApi01/Controllers/TelemetryController.cs
+++ b/source/App/source/ExampleHost.WebApi01/Controllers/TelemetryController.cs
@@ -34,8 +34,8 @@ public class TelemetryController : ControllerBase
     public async Task<string> GetAsync(string identification)
     {
         var traceparent = HttpContext.Request.Headers["traceparent"].ToString();
-        _logger.LogInformation($"ExampleHost WebApi01 {identification} Information: We should be able to find this log message by following the trace of the request '{traceparent}'.");
-        _logger.LogWarning($"ExampleHost WebApi01 {identification} Warning: We should be able to find this log message by following the trace of the request '{traceparent}'.");
+        _logger.LogInformation("ExampleHost WebApi01 {identification} Information: We should be able to find this log message by following the trace of the request '{traceparent}'.", identification, traceparent);
+        _logger.LogWarning("ExampleHost WebApi01 {identification} Warning: We should be able to find this log message by following the trace of the request '{traceparent}'.", identification, traceparent);
 
         var httpClient = _httpClientFactory.CreateClient(HttpClientNames.WebApi02);
         using var request = new HttpRequestMessage(HttpMethod.Get, $"webapi02/telemetry/{identification}");

--- a/source/App/source/ExampleHost.WebApi02/Controllers/TelemetryController.cs
+++ b/source/App/source/ExampleHost.WebApi02/Controllers/TelemetryController.cs
@@ -31,8 +31,8 @@ public class TelemetryController : ControllerBase
     public string Get(string identification)
     {
         var traceparent = HttpContext.Request.Headers["traceparent"].ToString();
-        _logger.LogInformation($"ExampleHost WebApi02 {identification} Information: We should be able to find this log message by following the trace of the request '{traceparent}'.");
-        _logger.LogWarning($"ExampleHost WebApi02 {identification} Warning: We should be able to find this log message by following the trace of the request '{traceparent}'.");
+        _logger.LogInformation("ExampleHost WebApi02 {identification} Information: We should be able to find this log message by following the trace of the request '{traceparent}'.", identification, traceparent);
+        _logger.LogWarning("ExampleHost WebApi02 {identification} Warning: We should be able to find this log message by following the trace of the request '{traceparent}'.", identification, traceparent);
 
         return identification;
     }


### PR DESCRIPTION
## Description

Logger messages should use message-templates and not string-interpolation.

## Quality

- [ ] Documentation is updated
- [ ] Release notes are updated
- [ ] Package version is updated
- [ ] Public types and methods are documented
- [ ] Tests are implemented and executed locally
