### PR TITLE
TestCommon: Support other SQL database collations than default

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,11 @@
 # TestCommon Release notes
 
+## Version 5.2.0
+
+- Changes to `SqlServerDatabaseManager`:
+    - Extended constructor of `SqlServerDatabaseManager` with parameter `collationName` to support the creation of databases with other collation names than the `DefaultCollationName`.
+    - Added const `DurableTaskCollationName` to allow easy access to the collation name necessary for the Durable Task SQL Provider.
+
 ## Version 5.1.2
 
 - No functional change

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Database/SqlServerDatabaseManagerTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Database/SqlServerDatabaseManagerTests.cs
@@ -25,11 +25,12 @@ public class SqlServerDatabaseManagerTests
     [Collection(nameof(SqlServerDatabaseCollectionFixture))]
     public class CreateDatabase
     {
-        [Fact]
-        public async Task When_DbContextIsConfigured_Then_DatabaseCanBeCreatedAsync()
+        [Theory]
+        [MemberData(nameof(GetCollationName), MemberType = typeof(SqlServerDatabaseManagerTests))]
+        public async Task When_DbContextIsConfigured_Then_DatabaseCanBeCreatedAsync(string collationName)
         {
             // Arrange
-            var sut = new SqlServerDatabaseManagerSut();
+            var sut = new SqlServerDatabaseManagerSut(collationName);
 
             // Act
             var databaseCreated = await sut.CreateDatabaseAsync();
@@ -58,11 +59,12 @@ public class SqlServerDatabaseManagerTests
             await context.Database.EnsureDeletedAsync();
         }
 
-        [Fact]
-        public void When_DbContextIsConfigured_Then_DatabaseCanBeCreated()
+        [Theory]
+        [MemberData(nameof(GetCollationName), MemberType = typeof(SqlServerDatabaseManagerTests))]
+        public void When_DbContextIsConfigured_Then_DatabaseCanBeCreated(string collationName)
         {
             // Arrange
-            var sut = new SqlServerDatabaseManagerSut();
+            var sut = new SqlServerDatabaseManagerSut(collationName);
 
             // Act
             var databaseCreated = sut.CreateDatabase();
@@ -182,11 +184,22 @@ public class SqlServerDatabaseManagerTests
         {
         }
 
+        public SqlServerDatabaseManagerSut(string collationName)
+            : base(nameof(SqlServerDatabaseManagerSut), collationName)
+        {
+        }
+
         public override ExampleDbContext CreateDbContext()
         {
             var optionsBuilder = new DbContextOptionsBuilder<ExampleDbContext>();
             optionsBuilder.UseSqlServer(ConnectionString);
             return new ExampleDbContext(optionsBuilder.Options);
         }
+    }
+
+    public static IEnumerable<object[]> GetCollationName()
+    {
+        yield return new object[] { SqlServerDatabaseManager<ExampleDbContext>.DefaultCollationName };
+        yield return new object[] { SqlServerDatabaseManager<ExampleDbContext>.DurableTaskCollationName };
     }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>5.1.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>5.2.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>5.1.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>5.2.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

- [x] Extended constructor of `SqlServerDatabaseManager` with parameter `collationName` to support the creation of databases with other collation names than the `DefaultCollationName`.
- [x] Added const `DurableTaskCollationName` to allow easy access to the collation name necessary for the Durable Task SQL Provider.

## Quality

- [ ] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [ ] Public types and methods are documented
- [x] Tests are implemented and executed locally
