### PR TITLE
chore: Add Team Mosaic as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Reference: <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners>
 
-* @FirestarJes @dstenroejl @Sondergaard @jonasdmoeller @HenrikSommer @RasmusGraabaek @michaelmajgaard
+* @FirestarJes @dstenroejl @Sondergaard @jonasdmoeller @HenrikSommer @RasmusGraabaek @michaelmajgaard @Energinet-DataHub/team-mosaic


### PR DESCRIPTION
## Description

Add Team Mosaic as CODEOWNERS, since they now are responsible for the `geh-core` package

## Quality

- [ ] Documentation is updated
- ~~[ ] Release notes are updated~~
- ~~[ ] Package version is updated~~
- ~~[ ] Public types and methods are documented~~
- ~~[ ] Tests are implemented and executed locally~~
