### PR TITLE
Simple implementation for StructArray

### DIFF
--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Databricks Release Notes
 
+## Version 10.1.0
+
+- Add support for `DatabricksSqlStatementClient` to execute SQL statements that returns StructArray in Apache Arrow format.
+
 ## Version 10.0.2
 
 - No functional change

--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-    <PackageVersion>10.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>10.1.0$(VersionSuffix)</PackageVersion>
     <Title>Databricks Jobs</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/Formats/IArrowArrayExtensions.cs
+++ b/source/Databricks/source/SqlStatementExecution/Formats/IArrowArrayExtensions.cs
@@ -40,7 +40,7 @@ internal static class IArrowArrayExtensions
             Decimal128Array decimal128Array => decimal128Array.GetValue(i),
             StringArray stringArray => stringArray.GetString(i),
             ListArray listArray => ReadArray(listArray, i),
-            StructArray structArray => ReadStruct(structArray),
+            StructArray structArray => ReadStructArray(structArray, i),
             _ => throw new NotSupportedException($"Unsupported data type {arrowArray}"),
         };
 
@@ -56,7 +56,7 @@ internal static class IArrowArrayExtensions
         return objectArray;
     }
 
-    private static object? ReadStruct(StructArray array)
+    private static object? ReadStructArray(StructArray array, int i)
     {
         if (array.Data.DataType is not StructType structType)
             return null;

--- a/source/Databricks/source/SqlStatementExecution/Formats/IArrowArrayExtensions.cs
+++ b/source/Databricks/source/SqlStatementExecution/Formats/IArrowArrayExtensions.cs
@@ -61,20 +61,14 @@ internal static class IArrowArrayExtensions
         if (array.Data.DataType is not StructType structType)
             return null;
 
-        var objectArray = new object?[array.Length];
-        for (var j = 0; j < array.Length; j++)
+        var structObject = new ExpandoObject();
+        for (var k = 0; k < structType.Fields.Count; k++)
         {
-            var structObject = new ExpandoObject();
-            for (var k = 0; k < structType.Fields.Count; k++)
-            {
-                var field = structType.Fields[k];
-                var value = array.Fields[k].GetValue(j);
-                ((IDictionary<string, object?>)structObject).Add(field.Name, value);
-            }
-
-            objectArray[j] = structObject;
+            var field = structType.Fields[k];
+            var value = array.Fields[k].GetValue(i);
+            ((IDictionary<string, object?>)structObject).Add(field.Name, value);
         }
 
-        return objectArray;
+        return structObject;
     }
 }

--- a/source/Databricks/source/SqlStatementExecution/Formats/IArrowArrayExtensions.cs
+++ b/source/Databricks/source/SqlStatementExecution/Formats/IArrowArrayExtensions.cs
@@ -40,7 +40,7 @@ internal static class IArrowArrayExtensions
             Decimal128Array decimal128Array => decimal128Array.GetValue(i),
             StringArray stringArray => stringArray.GetString(i),
             ListArray listArray => ReadArray(listArray, i),
-            StructArray structArray => ReadStruct(structArray, i),
+            StructArray structArray => ReadStruct(structArray),
             _ => throw new NotSupportedException($"Unsupported data type {arrowArray}"),
         };
 
@@ -56,7 +56,7 @@ internal static class IArrowArrayExtensions
         return objectArray;
     }
 
-    private static object? ReadStruct(StructArray array, int i)
+    private static object? ReadStruct(StructArray array)
     {
         if (array.Data.DataType is not StructType structType)
             return null;

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>10.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>10.1.0$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Add support for StructArray from Databricks SQL API in ApacheArrow format.

A query in this format

``` sql
SELECT * FROM VALUES
('Centrum', array(struct(5, 'd'), struct(7, 'z'))),
('Zen', array(struct(1, 'a'), struct(2, 'b'))) as data(name, ts)
```

will produce a dynamic type in C# that when serialised to JSON will look like this:

``` json
[
  {
    "name": "Centrum",
    "ts": [
      {
        "col1": 5,
        "col2": "d"
      },
      {
        "col1": 7,
        "col2": "z"
      }
    ]
  },
  {
    "name": "Zen",
    "ts": [
      {
        "col1": 1,
        "col2": "a"
      },
      {
        "col1": 2,
        "col2": "b"
      }
    ]
  }
]
```

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
