### PR TITLE
chore: Remove unused System.Text.Json package reference

### DIFF
--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Databricks Release Notes
 
+## Version 11.0.1
+
+Remove `System.Text.Json` package since it is covered by the runtime.
+
 ## Version 11.0.0
 
 - Add support for above 2 GB results.

--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-    <PackageVersion>11.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>11.0.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks Jobs</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -82,6 +82,5 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NodaTime" Version="3.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 </Project>

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>11.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>11.0.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
This version is identified as prone to DoS attack. This has been resolved in later framework versions.

The package can safely be removed since it's covered by the runtime.

## Description

<!--- Please leave a helpful description of the pull request here --->

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [ ] Public types and methods are documented
- [ ] Tests are implemented and executed locally
