### PR TITLE
Logging: Mark Azure Functions related logging extensions as obsolete

### DIFF
--- a/source/Logging/documents/release-notes/release-notes.md
+++ b/source/Logging/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Logging Middleware for Request and Response Release notes
 
+## Version 3.2.0
+
+- Mark Azure Function related dependency injection extensions `AddFunctionLoggingScope` and `UseLoggingScope` as obsolete.
+
 ## Version 3.1.5
 
 - Bump System.IdentityModel.Tokens.Jwt from 6.15.0 to 6.34.0 because of CVE-2024-21319

--- a/source/Logging/source/Logging/Logging.csproj
+++ b/source/Logging/source/Logging/Logging.csproj
@@ -26,7 +26,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Logging</PackageId>
-    <PackageVersion>3.1.5$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.2.0$(VersionSuffix)</PackageVersion>
     <Title>Logging</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Logging/source/LoggingMiddleware/LoggingMiddleware.csproj
+++ b/source/Logging/source/LoggingMiddleware/LoggingMiddleware.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Logging.LoggingMiddleware</PackageId>
-    <PackageVersion>3.1.5$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.2.0$(VersionSuffix)</PackageVersion>
     <Title>Logging Middleware</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Logging/source/LoggingMiddleware/Registration.cs
+++ b/source/Logging/source/LoggingMiddleware/Registration.cs
@@ -32,6 +32,7 @@ public static class Registration
         return services;
     }
 
+    [Obsolete("Use 'AddApplicationInsightsForIsolatedWorker' from the 'Energinet.DataHub.Core.App.FunctionApp' NuGet package.")]
     public static IServiceCollection AddFunctionLoggingScope(this IServiceCollection services, string domain)
     {
         RegisterLoggingScope(services, domain);
@@ -45,6 +46,7 @@ public static class Registration
         return app.UseMiddleware<HttpLoggingScopeMiddleware>();
     }
 
+    [Obsolete("Not needed when using 'AddApplicationInsightsForIsolatedWorker' from the 'Energinet.DataHub.Core.App.FunctionApp' NuGet package.")]
     public static IFunctionsWorkerApplicationBuilder UseLoggingScope(this IFunctionsWorkerApplicationBuilder builder)
     {
         return builder.UseMiddleware<FunctionLoggingScopeMiddleware>();


### PR DESCRIPTION
## Description

Mark Azure Functions related logging extensions as obsolete.

## Quality

- [ ] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [ ] Public types and methods are documented
- [ ] Tests are implemented and executed locally
