### PR TITLE
refac: Enable AzuriteManager to run azurite silently

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 6.2.0
+
+- Added parameter `UseSilentMode` with default value `true` to `AzuriteManager`. This disables access log output, which can be useful to reduce noise in test logs.
+
 ## Version 6.1.0
 
 - Added `OpenIdJwtManager` to enable testing DH3 applications that requires OpenId and JWT for HTTP authentication and authorization, with the following features:

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/FunctionApp.TestCommon.Tests.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/FunctionApp.TestCommon.Tests.csproj
@@ -23,15 +23,15 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Azurite/AzuriteManagerTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Azurite/AzuriteManagerTests.cs
@@ -99,7 +99,7 @@ public class AzuriteManagerTests
     public class Given_Construction
     {
         [Fact]
-        public void When_Default_Then_UseSilentModeIsFalse()
+        public void When_Default_Then_UseSilentModeIsTrue()
         {
             // Act
             using var sut = new AzuriteManager();
@@ -109,7 +109,7 @@ public class AzuriteManagerTests
         }
 
         [Fact]
-        public void When_UseSilentModeIsFalse_Then_UseSilentModeIsFalse()
+        public void When_SetUseSilentModeToFalse_Then_UseSilentModeIsFalse()
         {
             // Act
             using var sut = new AzuriteManager(useSilentMode: false);

--- a/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Azurite/AzuriteManagerTests.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon.Tests/Integration/Azurite/AzuriteManagerTests.cs
@@ -96,6 +96,29 @@ public class AzuriteManagerTests
         }
     }
 
+    public class Given_Construction
+    {
+        [Fact]
+        public void When_Default_Then_UseSilentModeIsFalse()
+        {
+            // Act
+            using var sut = new AzuriteManager();
+
+            // Assert
+            sut.UseSilentMode.Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_UseSilentModeIsFalse_Then_UseSilentModeIsFalse()
+        {
+            // Act
+            using var sut = new AzuriteManager(useSilentMode: false);
+
+            // Assert
+            sut.UseSilentMode.Should().BeFalse();
+        }
+    }
+
     /// <summary>
     /// When using Azurite with OAuth we must use Https and 'localhost' (not '127.0.0.1').
     ///

--- a/source/TestCommon/source/FunctionApp.TestCommon/Azurite/AzuriteManager.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Azurite/AzuriteManager.cs
@@ -15,7 +15,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Management;
-using System.Security.Cryptography.X509Certificates;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.TestCertificate;
 
 namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;

--- a/source/TestCommon/source/FunctionApp.TestCommon/Azurite/AzuriteManager.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Azurite/AzuriteManager.cs
@@ -15,6 +15,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Management;
+using System.Text;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.TestCertificate;
 
 namespace Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
@@ -58,9 +59,10 @@ public class AzuriteManager : IDisposable
     /// <summary>
     /// Create manager to startup Azurite.
     /// </summary>
-    public AzuriteManager(bool useOAuth = false)
+    public AzuriteManager(bool useOAuth = false, bool useSilentMode = true)
     {
         UseOAuth = useOAuth;
+        UseSilentMode = useSilentMode;
         FullConnectionString = BuildConnectionString(UseOAuth, useBlob: true, useQueue: true, useTable: true);
         BlobStorageConnectionString = BuildConnectionString(UseOAuth, useBlob: true);
         BlobStorageServiceUri = BuildServiceUri(UseOAuth, BlobServicePort);
@@ -74,6 +76,11 @@ public class AzuriteManager : IDisposable
     /// If true then start Azurite with OAuth and HTTPS options.
     /// </summary>
     public bool UseOAuth { get; }
+
+    /// <summary>
+    /// If true then start Azurite silent mode (disable output of the access log).
+    /// </summary>
+    public bool UseSilentMode { get; }
 
     /// <summary>
     /// Connection string for connecting to all Azurite services (blob, queue, table).
@@ -277,7 +284,7 @@ public class AzuriteManager : IDisposable
     private void StartAzuriteProcess()
     {
         var azuriteCommandFilePath = GetAzuriteCommandFilePath();
-        var azuriteArguments = GetAzuriteArguments(UseOAuth);
+        var azuriteArguments = GetAzuriteArguments(UseOAuth, UseSilentMode);
 
         if (UseOAuth)
             TestCertificateProvider.InstallCertificate();
@@ -330,10 +337,20 @@ public class AzuriteManager : IDisposable
             : Path.Combine(azuriteFolderPath, azuriteFileName);
     }
 
-    private static string GetAzuriteArguments(bool useOAuth)
+    private static string GetAzuriteArguments(bool useOAuth, bool useSilentMode)
     {
-        return useOAuth == true
-            ? $"--oauth basic --cert {TestCertificateProvider.FilePath} --pwd {TestCertificateProvider.Password}"
-            : string.Empty;
+        var arguments = new List<string>();
+
+        if (useOAuth)
+        {
+            arguments.Add($"--oauth basic --cert {TestCertificateProvider.FilePath} --pwd {TestCertificateProvider.Password}");
+        }
+
+        if (useSilentMode)
+        {
+            arguments.Add("--silent");
+        }
+
+        return string.Join(" ", arguments);
     }
 }

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>6.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.2.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>
@@ -70,7 +70,7 @@ limitations under the License.
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Content Include="TestCertificate\test-common-cert.pfx">
       <PackageCopyToOutput>true</PackageCopyToOutput>

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -80,30 +80,30 @@ limitations under the License.
 
 
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.11.3" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.11.5" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.5" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="Microsoft.Azure.Management.EventHub" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageReference Include="Polly" Version="8.4.0" />
+    <PackageReference Include="Polly" Version="8.4.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Management" Version="8.0.0" />
-    <PackageReference Include="WireMock.Net" Version="1.5.62" />
-    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="WireMock.Net" Version="1.6.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/TestCommon/source/TestCommon.Tests/TestCommon.Tests.csproj
+++ b/source/TestCommon/source/TestCommon.Tests/TestCommon.Tests.csproj
@@ -24,10 +24,10 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -83,7 +83,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
   </ItemGroup>
 
 </Project>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>6.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.2.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

When using azurite we see a lot of noise in the console and test logs. This PR enables azurite to run silentyl by default, but still allow developers to choose to output the log as previously.

## Quality

- [ ] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
