### PR TITLE
Experimental: Add parallel versions of ExecuteStatement (Do not review yet or merge)

### DIFF
--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Databricks Release Notes
 
+## Version 11.1.1
+- Add parallel execution for fetching of databricks result chunks.
+
+
 ## Version 11.1.0
 
 - Update NuGet package dependencies and refactor code accordingly.

--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,8 +1,8 @@
 # Databricks Release Notes
 
 ## Version 11.1.1
-- Add parallel execution for fetching of databricks result chunks.
 
+- Add parallel execution for fetching of databricks result chunks.
 
 ## Version 11.1.0
 

--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-    <PackageVersion>11.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>11.1.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks Jobs</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
+++ b/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
@@ -122,7 +122,7 @@ public class DatabricksSqlWarehouseQueryExecutor
         Format format,
         [EnumeratorCancellation]CancellationToken cancellationToken = default)
     {
-        await foreach (var record in DoExecuteStatementAsync(statement, format, cancellationToken).ConfigureAwait(false))
+        await foreach (var record in DoExecuteStatementParallelAsync(statement, format, cancellationToken).ConfigureAwait(false))
         {
             yield return record;
         }

--- a/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
+++ b/source/Databricks/source/SqlStatementExecution/DatabricksSqlWarehouseQueryExecutor.cs
@@ -234,7 +234,7 @@ public class DatabricksSqlWarehouseQueryExecutor
             yield break;
         }
 
-        foreach (var requestChunks in response.manifest.chunks.Chunk(3))
+        foreach (var requestChunks in response.manifest.chunks.Chunk(6))
         {
             var tasks = requestChunks.Select(chunk => FetchChunkAsync(chunk, response, strategy, cancellationToken)).ToArray();
             Task.WaitAll(tasks);

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>11.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>11.1.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Experimental initial implementation of parallel fetching of results from databricks

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [ ] Tests are implemented and executed locally
