### PR TITLE
Support nullable parameters

### DIFF
--- a/source/Databricks/documents/release-notes/release-notes.md
+++ b/source/Databricks/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Databricks Release Notes
 
+## Version 11.1.1
+
+- Fix handling of null values in constructor when using `StronglyTypedApacheArrowFormat`
+
 ## Version 11.1.0
 
 - Update NuGet package dependencies and refactor code accordingly.

--- a/source/Databricks/source/Jobs/Jobs.csproj
+++ b/source/Databricks/source/Jobs/Jobs.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.Jobs</PackageId>
-    <PackageVersion>11.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>11.1.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks Jobs</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/ObjectCreationTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/ObjectCreationTests.cs
@@ -91,7 +91,7 @@ public class ObjectCreationTests : IClassFixture<DatabricksSqlWarehouseFixture>
         var result = client.ExecuteStatementAsync<PersonWithTitle>(NullStatement);
         var persons = await result.ToListAsync();
 
-        Assert.Equal(2, persons.Count);
+        persons.Count.Should().Be(2);
     }
 
     public class ReallyBadPerson

--- a/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/ObjectCreationTests.cs
+++ b/source/Databricks/source/SqlStatementExecution.IntegrationTests/Client/ObjectCreationTests.cs
@@ -31,6 +31,11 @@ public class ObjectCreationTests : IClassFixture<DatabricksSqlWarehouseFixture>
               ('Jack N' , 16) AS data(name, age)")
         .Build();
 
+    private static DatabricksStatement NullStatement => DatabricksStatement.FromRawSql(@"SELECT * FROM VALUES
+('Jack N' , 16, 'Developer'),
+('Null N' , 27, NULL) AS data(name, age, title)")
+        .Build();
+
     public ObjectCreationTests(DatabricksSqlWarehouseFixture sqlWarehouseFixture)
     {
         _sqlWarehouseFixture = sqlWarehouseFixture;
@@ -78,6 +83,17 @@ public class ObjectCreationTests : IClassFixture<DatabricksSqlWarehouseFixture>
         await act.Should().ThrowAsync<ArgumentException>();
     }
 
+    [Fact]
+    public async Task AResponseWithNullValues_WhenMappedToANullableProperty_ThenTheObjectIsCreated()
+    {
+        var client = _sqlWarehouseFixture.CreateSqlStatementClient();
+
+        var result = client.ExecuteStatementAsync<PersonWithTitle>(NullStatement);
+        var persons = await result.ToListAsync();
+
+        Assert.Equal(2, persons.Count);
+    }
+
     public class ReallyBadPerson
     {
         public string Name { get; private set; }
@@ -105,4 +121,9 @@ public class ObjectCreationTests : IClassFixture<DatabricksSqlWarehouseFixture>
     public record Person(
         [property: ArrowField("name", 1)] string Name,
         [property: ArrowField("age", 2)] int Age);
+
+    public record PersonWithTitle(
+        [property: ArrowField("name", 1)] string Name,
+        [property: ArrowField("age", 2)] int Age,
+        [property: ArrowField("title", 3)] string? Title);
 }

--- a/source/Databricks/source/SqlStatementExecution/Formats/Reflections.cs
+++ b/source/Databricks/source/SqlStatementExecution/Formats/Reflections.cs
@@ -93,8 +93,18 @@ internal static class Reflections
                 var index = Expression.Constant(i);
                 var parameterType = parameters[i].ParameterType;
                 var accessor = Expression.ArrayIndex(param, index);
-                var typeMatch = Expression.TypeIs(accessor, parameterType);
-                checks[i] = typeMatch;
+
+                // Check if the parameter type is nullable
+                if (parameterType.IsValueType && Nullable.GetUnderlyingType(parameterType) == null)
+                {
+                    checks[i] = Expression.TypeIs(accessor, parameterType);
+                }
+                else
+                {
+                    checks[i] = Expression.OrElse(
+                        Expression.Equal(accessor, Expression.Constant(null)),
+                        Expression.TypeIs(accessor, parameterType));
+                }
             }
 
             var allChecks = checks.Aggregate(Expression.AndAlso);

--- a/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
+++ b/source/Databricks/source/SqlStatementExecution/SqlStatementExecution.csproj
@@ -30,7 +30,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.Databricks.SqlStatementExecution</PackageId>
-    <PackageVersion>11.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>11.1.1$(VersionSuffix)</PackageVersion>
     <Title>Databricks SQL Statement Execution</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

The object creation did not support null-values.

With this change it can assign null-values to properties. 

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
