### PR TITLE
Use StoreName.My for Azurite test certificate

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 7.1.0
+
+- Use My store instead of Root store in AzuriteManager for TestCommon.
+
 ## Version 7.0.0
 
 - Refactored class `IntegrationTestConfiguration`:

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>7.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>7.1.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/TestCertificate/TestCertificateProvider.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/TestCertificate/TestCertificateProvider.cs
@@ -64,7 +64,7 @@ internal static class TestCertificateProvider
             storeLocation = StoreLocation.LocalMachine;
         }
 
-        using var certificateStore = new X509Store(StoreName.Root, storeLocation);
+        using var certificateStore = new X509Store(StoreName.My, storeLocation);
         certificateStore.Open(OpenFlags.ReadWrite);
 
         using var testCertificate = new X509Certificate2(FilePath, Password);

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>7.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>7.1.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

When using StoreName.Root for the Azurite test certificate we loose cross-platform developer capabilities, since the root store is only accessible on Windows and partly on Linux ([link](https://learn.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography#the-root-store)).

This PR edits the store used for the Azurite test certificate to `My` store instead of `Root` store.

## Quality

- [ ] Documentation is updated
- [ ] Release notes are updated
- [ ] Package version is updated
- [ ] Public types and methods are documented
- [ ] Tests are implemented and executed locally
