### PR TITLE
Configure Dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
+
 - package-ecosystem: "nuget"
   directory: /source/Databricks
   schedule:
@@ -19,6 +20,7 @@ updates:
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
+
 - package-ecosystem: "nuget"
   directory: /source/FeatureManagement
   schedule:
@@ -26,6 +28,7 @@ updates:
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
+
 - package-ecosystem: "nuget"
   directory: /source/JsonSerialization
   schedule:
@@ -33,6 +36,7 @@ updates:
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
+
 - package-ecosystem: "nuget"
   directory: /source/Logging
   schedule:
@@ -40,6 +44,7 @@ updates:
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
+
 - package-ecosystem: "nuget"
   directory: /source/Messaging
   schedule:
@@ -47,6 +52,7 @@ updates:
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
+
 - package-ecosystem: "nuget"
   directory: /source/Outbox
   schedule:
@@ -54,6 +60,7 @@ updates:
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
+
 - package-ecosystem: "nuget"
   directory: /source/TestCommon
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/source/Outbox" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "Microsoft.*"
+        versions: ["9.*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,59 @@
 
 version: 2
 updates:
-  - package-ecosystem: "nuget"
-    directories:
-      - /source/App
-      - /source/Databricks
-      - /source/FeatureManagement
-      - /source/JsonSerialization
-      - /source/Logging
-      - /source/Messaging
-      - /source/Outbox
-      - /source/TestCommon
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "Microsoft.*"
-        versions: ["999.*"]
-        
+- package-ecosystem: "nuget"
+  directory: /source/App
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "Microsoft.*"
+    versions: [ "999.*" ]
+- package-ecosystem: "nuget"
+  directory: /source/Databricks
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "Microsoft.*"
+    versions: [ "999.*" ]
+- package-ecosystem: "nuget"
+  directory: /source/FeatureManagement
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "Microsoft.*"
+    versions: [ "999.*" ]
+- package-ecosystem: "nuget"
+  directory: /source/JsonSerialization
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "Microsoft.*"
+    versions: [ "999.*" ]
+- package-ecosystem: "nuget"
+  directory: /source/Logging
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "Microsoft.*"
+    versions: [ "999.*" ]
+- package-ecosystem: "nuget"
+  directory: /source/Messaging
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "Microsoft.*"
+    versions: [ "999.*" ]
+- package-ecosystem: "nuget"
+  directory: /source/Outbox
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "Microsoft.*"
+    versions: [ "999.*" ]
+- package-ecosystem: "nuget"
+  directory: /source/TestCommon
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "Microsoft.*"
+    versions: [ "999.*" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/source/Outbox" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
   directory: /source/App
   schedule:
     interval: "weekly"
+  groups:
+    app-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    app-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
@@ -17,6 +27,16 @@ updates:
   directory: /source/Databricks
   schedule:
     interval: "weekly"
+  groups:
+    databricks-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    databricks-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
@@ -25,6 +45,16 @@ updates:
   directory: /source/FeatureManagement
   schedule:
     interval: "weekly"
+  groups:
+    feature-management-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    feature-management-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
@@ -33,6 +63,16 @@ updates:
   directory: /source/JsonSerialization
   schedule:
     interval: "weekly"
+  groups:
+    json-serialization-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    json-serialization-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
@@ -41,6 +81,16 @@ updates:
   directory: /source/Logging
   schedule:
     interval: "weekly"
+  groups:
+    logging-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    logging-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
@@ -49,6 +99,16 @@ updates:
   directory: /source/Messaging
   schedule:
     interval: "weekly"
+  groups:
+    messaging-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    messaging-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
@@ -57,6 +117,16 @@ updates:
   directory: /source/Outbox
   schedule:
     interval: "weekly"
+  groups:
+    outbox-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    outbox-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]
@@ -65,6 +135,16 @@ updates:
   directory: /source/TestCommon
   schedule:
     interval: "weekly"
+  groups:
+    test-common-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    test-common-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
   ignore:
   - dependency-name: "Microsoft.*"
     versions: [ "999.*" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,19 @@
 
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/source/Outbox" # Location of package manifests
+  - package-ecosystem: "nuget"
+    directories:
+      - /source/App
+      - /source/Databricks
+      - /source/FeatureManagement
+      - /source/JsonSerialization
+      - /source/Logging
+      - /source/Messaging
+      - /source/Outbox
+      - /source/TestCommon
     schedule:
       interval: "weekly"
     ignore:
       - dependency-name: "Microsoft.*"
-        versions: ["9.*"]
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/source/App" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "Microsoft.*"
-        versions: ["9.*"]
+        versions: ["999.*"]
+        

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
     ignore:
       - dependency-name: "Microsoft.*"
         versions: ["9.*"]
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/source/App" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "Microsoft.*"
+        versions: ["9.*"]


### PR DESCRIPTION
This pull request introduces a new configuration file for Dependabot to automate dependency updates for various projects. The configuration specifies the package ecosystems, directories, update schedules, and grouping of updates.

Key changes include:

* Added a new `.github/dependabot.yml` file to configure Dependabot for automated dependency updates. The configuration includes:
  * Specifying the `nuget` package ecosystem for multiple directories.
  * Setting the update schedule to weekly.
  * Grouping updates into minor and patch updates, and security updates.
  * Ignoring updates for dependencies matching the pattern "Microsoft.*" with version "999.*".