### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,9 @@ updates:
       - "*" # Applies to all security updates
   ignore:
   - dependency-name: Microsoft.Extensions.*
-    versions: [ "9.*" ]
+    versions: [9.*]
   - dependency-name: Microsoft.EntityFrameworkCore.*
-    versions: [ "9.*" ]
+    versions: [9.*]
 
 - package-ecosystem: nuget
   directory: /source/Databricks
@@ -52,7 +52,7 @@ updates:
       - "*" # Applies to all security updates
   ignore:
   - dependency-name: Microsoft.Extensions.*
-    versions: [ "9.*" ]
+    versions: [9.*]
 
 - package-ecosystem: nuget
   directory: /source/FeatureManagement
@@ -100,7 +100,7 @@ updates:
       - "*" # Applies to all security updates
   ignore:
   - dependency-name: Microsoft.Extensions.*
-    versions: [ "9.*" ]
+    versions: [9.*]
 
 - package-ecosystem: nuget
   directory: /source/Messaging
@@ -118,7 +118,7 @@ updates:
       - "*" # Applies to all security updates
   ignore:
   - dependency-name: Microsoft.Extensions.*
-    versions: [ "9.*" ]
+    versions: [9.*]
 
 - package-ecosystem: nuget
   directory: /source/Outbox
@@ -136,7 +136,7 @@ updates:
       - "*" # Applies to all security updates
   ignore:
   - dependency-name: Microsoft.EntityFrameworkCore.*
-    versions: [ "9.*" ]
+    versions: [9.*]
 
 - package-ecosystem: nuget
   directory: /source/TestCommon
@@ -154,6 +154,6 @@ updates:
       - "*" # Applies to all security updates
   ignore:
   - dependency-name: Microsoft.Extensions.*
-    versions: [ "9.*" ]
+    versions: [9.*]
   - dependency-name: Microsoft.EntityFrameworkCore.*
-    versions: [ "9.*" ]
+    versions: [9.*]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,177 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  groups:
+    security:
+      applies-to: security-updates
+      patterns:
+        - "*"
+          
+- package-ecosystem: "nuget"
+  directory: /source/App
+  schedule:
+    interval: "weekly"
+  groups:
+    app-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    app-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
+  ignore:
+  - dependency-name: "Microsoft.Extensions.*"
+    versions: [ "9.*" ]
+  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+    versions: [ "9.*" ]
+
+- package-ecosystem: "nuget"
+  directory: /source/Databricks
+  schedule:
+    interval: "weekly"
+  groups:
+    databricks-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    databricks-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
+  ignore:
+  - dependency-name: "Microsoft.Extensions.*"
+    versions: [ "9.*" ]
+  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+    versions: [ "9.*" ]
+
+- package-ecosystem: "nuget"
+  directory: /source/FeatureManagement
+  schedule:
+    interval: "weekly"
+  groups:
+    feature-management-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    feature-management-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
+  ignore:
+  - dependency-name: "Microsoft.Extensions.*"
+    versions: [ "9.*" ]
+  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+    versions: [ "9.*" ]
+
+- package-ecosystem: "nuget"
+  directory: /source/JsonSerialization
+  schedule:
+    interval: "weekly"
+  groups:
+    json-serialization-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    json-serialization-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
+  ignore:
+  - dependency-name: "Microsoft.Extensions.*"
+    versions: [ "9.*" ]
+  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+    versions: [ "9.*" ]
+
+- package-ecosystem: "nuget"
+  directory: /source/Logging
+  schedule:
+    interval: "weekly"
+  groups:
+    logging-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    logging-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
+  ignore:
+  - dependency-name: "Microsoft.Extensions.*"
+    versions: [ "9.*" ]
+  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+    versions: [ "9.*" ]
+
+- package-ecosystem: "nuget"
+  directory: /source/Messaging
+  schedule:
+    interval: "weekly"
+  groups:
+    messaging-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    messaging-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
+  ignore:
+  - dependency-name: "Microsoft.Extensions.*"
+    versions: [ "9.*" ]
+  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+    versions: [ "9.*" ]
+
+- package-ecosystem: "nuget"
+  directory: /source/Outbox
+  schedule:
+    interval: "weekly"
+  groups:
+    outbox-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    outbox-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
+  ignore:
+  - dependency-name: "Microsoft.Extensions.*"
+    versions: [ "9.*" ]
+  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+    versions: [ "9.*" ]
+
+- package-ecosystem: "nuget"
+  directory: /source/TestCommon
+  schedule:
+    interval: "weekly"
+  groups:
+    test-common-package-minor-and-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    test-common-package-security:
+      applies-to: security-updates
+      patterns:
+      - "*" # Applies to all security updates
+  ignore:
+  - dependency-name: "Microsoft.Extensions.*"
+    versions: [ "9.*" ]
+  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+    versions: [ "9.*" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,12 @@ updates:
     security:
       applies-to: security-updates
       patterns:
-        - "*"
-          
-- package-ecosystem: "nuget"
+      - "*"
+
+- package-ecosystem: nuget
   directory: /source/App
   schedule:
-    interval: "weekly"
+    interval: weekly
   groups:
     app-package-minor-and-patch:
       applies-to: version-updates
@@ -31,15 +31,15 @@ updates:
       patterns:
       - "*" # Applies to all security updates
   ignore:
-  - dependency-name: "Microsoft.Extensions.*"
+  - dependency-name: Microsoft.Extensions.*
     versions: [ "9.*" ]
-  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+  - dependency-name: Microsoft.EntityFrameworkCore.*
     versions: [ "9.*" ]
 
-- package-ecosystem: "nuget"
+- package-ecosystem: nuget
   directory: /source/Databricks
   schedule:
-    interval: "weekly"
+    interval: weekly
   groups:
     databricks-package-minor-and-patch:
       applies-to: version-updates
@@ -51,15 +51,13 @@ updates:
       patterns:
       - "*" # Applies to all security updates
   ignore:
-  - dependency-name: "Microsoft.Extensions.*"
-    versions: [ "9.*" ]
-  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+  - dependency-name: Microsoft.Extensions.*
     versions: [ "9.*" ]
 
-- package-ecosystem: "nuget"
+- package-ecosystem: nuget
   directory: /source/FeatureManagement
   schedule:
-    interval: "weekly"
+    interval: weekly
   groups:
     feature-management-package-minor-and-patch:
       applies-to: version-updates
@@ -70,16 +68,11 @@ updates:
       applies-to: security-updates
       patterns:
       - "*" # Applies to all security updates
-  ignore:
-  - dependency-name: "Microsoft.Extensions.*"
-    versions: [ "9.*" ]
-  - dependency-name: "Microsoft.EntityFrameworkCore.*"
-    versions: [ "9.*" ]
 
-- package-ecosystem: "nuget"
+- package-ecosystem: nuget
   directory: /source/JsonSerialization
   schedule:
-    interval: "weekly"
+    interval: weekly
   groups:
     json-serialization-package-minor-and-patch:
       applies-to: version-updates
@@ -90,16 +83,11 @@ updates:
       applies-to: security-updates
       patterns:
       - "*" # Applies to all security updates
-  ignore:
-  - dependency-name: "Microsoft.Extensions.*"
-    versions: [ "9.*" ]
-  - dependency-name: "Microsoft.EntityFrameworkCore.*"
-    versions: [ "9.*" ]
 
-- package-ecosystem: "nuget"
+- package-ecosystem: nuget
   directory: /source/Logging
   schedule:
-    interval: "weekly"
+    interval: weekly
   groups:
     logging-package-minor-and-patch:
       applies-to: version-updates
@@ -111,15 +99,13 @@ updates:
       patterns:
       - "*" # Applies to all security updates
   ignore:
-  - dependency-name: "Microsoft.Extensions.*"
-    versions: [ "9.*" ]
-  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+  - dependency-name: Microsoft.Extensions.*
     versions: [ "9.*" ]
 
-- package-ecosystem: "nuget"
+- package-ecosystem: nuget
   directory: /source/Messaging
   schedule:
-    interval: "weekly"
+    interval: weekly
   groups:
     messaging-package-minor-and-patch:
       applies-to: version-updates
@@ -131,15 +117,13 @@ updates:
       patterns:
       - "*" # Applies to all security updates
   ignore:
-  - dependency-name: "Microsoft.Extensions.*"
-    versions: [ "9.*" ]
-  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+  - dependency-name: Microsoft.Extensions.*
     versions: [ "9.*" ]
 
-- package-ecosystem: "nuget"
+- package-ecosystem: nuget
   directory: /source/Outbox
   schedule:
-    interval: "weekly"
+    interval: weekly
   groups:
     outbox-package-minor-and-patch:
       applies-to: version-updates
@@ -151,15 +135,13 @@ updates:
       patterns:
       - "*" # Applies to all security updates
   ignore:
-  - dependency-name: "Microsoft.Extensions.*"
-    versions: [ "9.*" ]
-  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+  - dependency-name: Microsoft.EntityFrameworkCore.*
     versions: [ "9.*" ]
 
-- package-ecosystem: "nuget"
+- package-ecosystem: nuget
   directory: /source/TestCommon
   schedule:
-    interval: "weekly"
+    interval: weekly
   groups:
     test-common-package-minor-and-patch:
       applies-to: version-updates
@@ -171,7 +153,7 @@ updates:
       patterns:
       - "*" # Applies to all security updates
   ignore:
-  - dependency-name: "Microsoft.Extensions.*"
+  - dependency-name: Microsoft.Extensions.*
     versions: [ "9.*" ]
-  - dependency-name: "Microsoft.EntityFrameworkCore.*"
+  - dependency-name: Microsoft.EntityFrameworkCore.*
     versions: [ "9.*" ]


### PR DESCRIPTION
This pull request introduces a configuration for Dependabot to automate dependency updates for various package ecosystems within the repository. The configuration specifies update schedules, grouping rules, and ignores certain versions of dependencies.

Key changes include:

* **Dependabot Configuration**:
  * Added `.github/dependabot.yml` to specify package ecosystems and update schedules.
  * Configured daily updates for `github-actions` ecosystem.
  * Configured weekly updates for multiple `nuget` directories with specific grouping rules for minor, patch, and security updates.
  * Ignored updates for dependencies starting with `Microsoft.Extensions.*` and `Microsoft.EntityFrameworkCore.*` for version `9.*`.