### PR TITLE
Upgrade to .NET 9 - TestCommon

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/source/App/Directory.Build.props
+++ b/source/App/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/TestCommon/Directory.Build.props
+++ b/source/TestCommon/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 8.0.0
+
+- Upgrade from .NET 8 (8.0.100) to .NET 9 (9.0.100)
+
 ## Version 7.3.0
 
 - Add attributes to xUnit test methods: `ScenarioStepAttribute` to control execution order

--- a/source/TestCommon/source/DurableFunctionApp.TestCommon/DurableFunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/DurableFunctionApp.TestCommon/DurableFunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.DurableFunctionApp.TestCommon</PackageId>
-    <PackageVersion>7.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.0.0$(VersionSuffix)</PackageVersion>
     <Title>DurableFunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>7.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.0.0$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/TestCertificate/TestCertificateProvider.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/TestCertificate/TestCertificateProvider.cs
@@ -67,7 +67,7 @@ internal static class TestCertificateProvider
         using var certificateStore = new X509Store(StoreName.Root, storeLocation);
         certificateStore.Open(OpenFlags.ReadWrite);
 
-        using var testCertificate = new X509Certificate2(FilePath, Password);
+        using var testCertificate = X509CertificateLoader.LoadPkcs12FromFile(FilePath, Password);
         certificateStore.Add(testCertificate);
     }
 }

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>7.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.0.0$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Upgade TestCommon from .NET 8 (8.0.100) to .NET 9 (9.0.100)

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
