### PR TITLE
feat: full namespace support for Swagger generating SchemaIds

### DIFF
--- a/source/App/documents/registrations/swagger-api-version.md
+++ b/source/App/documents/registrations/swagger-api-version.md
@@ -40,6 +40,15 @@ After following the guidelines below, one should have a functional web api proje
 
 ### Additional configuration
 
+#### Support for SchemaIds using full namespace
+By default, the schema ids are generated using the name of the class. This may cause problems if you have multiple classes with the same name in different namespaces.
+To enable the full namespace, add the following to the `AddSwaggerForWebApp` method:
+
+```csharp
+builder.Services
+       .AddSwaggerForWebApp(Assembly.GetExecutingAssembly(), swaggerUITitle: $"{Title to dislay in swagger ui}", useFullNamespace: true);
+```
+
 #### Handling enums
 
 Enum names are add to the x-enumNames via source/App/source/WebApp/Extensibility/Swashbuckle/EnumExtensionSchemaFilter.cs so it is possible

--- a/source/App/documents/registrations/swagger-api-version.md
+++ b/source/App/documents/registrations/swagger-api-version.md
@@ -42,7 +42,7 @@ After following the guidelines below, one should have a functional web api proje
 
 #### Support for SchemaIds using full namespace
 
-By default, the schema ids are generated using the name of the class. This may cause problems if you have multiple classes with the same name in different namespaces.
+By default, the schema ids are generated using the name of the class. This may cause problems if you have multiple classes, with the same name in different namespaces.
 To enable the full namespace, add the following to the `AddSwaggerForWebApp` method:
 
 ```csharp

--- a/source/App/documents/registrations/swagger-api-version.md
+++ b/source/App/documents/registrations/swagger-api-version.md
@@ -41,6 +41,7 @@ After following the guidelines below, one should have a functional web api proje
 ### Additional configuration
 
 #### Support for SchemaIds using full namespace
+
 By default, the schema ids are generated using the name of the class. This may cause problems if you have multiple classes with the same name in different namespaces.
 To enable the full namespace, add the following to the `AddSwaggerForWebApp` method:
 

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 14.1.0
 
-- Add support for full namespace on types when creating SchemaIds in Swagger.
+- Added support for full namespace for `SchemaIds` in OpenApiExtensions.
 
 ## Version 14.0.4
 

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -2,6 +2,10 @@
 
 ## Version 14.0.3
 
+- Add support for full namespace on types when creating SchemaIds in Swagger.
+
+## Version 14.0.3
+
 - Update tj-actions to v46.0.1
 - No functional change.
 

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -1,13 +1,13 @@
 # App Release notes
 
+## Version 14.1.0
+
+- Add support for full namespace on types when creating SchemaIds in Swagger.
+
 ## Version 14.0.4
 
 - Fix build error. Warning: (IDE0040)
 - No functional change.
-
-## Version 14.0.3
-
-- Add support for full namespace on types when creating SchemaIds in Swagger.
 
 ## Version 14.0.3
 

--- a/source/App/source/Common.Abstractions/Common.Abstractions.csproj
+++ b/source/App/source/Common.Abstractions/Common.Abstractions.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Abstractions</PackageId>
-    <PackageVersion>14.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>14.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common/Common.csproj
+++ b/source/App/source/Common/Common.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common</PackageId>
-    <PackageVersion>14.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>14.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/ExampleHost.WebApi.Tests/Integration/SwaggerOpenApiTests.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Integration/SwaggerOpenApiTests.cs
@@ -112,4 +112,23 @@ public class SwaggerOpenApiTests
         actualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         actualResponse.Content.Headers.ContentType!.MediaType.Should().Be("text/html");
     }
+
+    [Fact]
+    public async Task SwaggerSupportFullNamespaceForSchemaIds()
+    {
+        // Arrange
+        var url = "swagger/v2/swagger.json";
+
+        // Act
+        var actualResponse = await Fixture.Web01HttpClient.GetAsync(url);
+
+        // Assert
+        using var assertionScope = new AssertionScope();
+        actualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        actualResponse.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+        var content = await actualResponse.Content.ReadAsStringAsync();
+        var swagger = System.Text.Json.JsonSerializer.Deserialize<JsonNode>(content);
+        var node = swagger?["components"]?["schemas"]?["ExampleHost.WebApi01.Common.EnumTest"];
+        node.Should().NotBeNull();
+    }
 }

--- a/source/App/source/ExampleHost.WebApi01/Startup.cs
+++ b/source/App/source/ExampleHost.WebApi01/Startup.cs
@@ -60,7 +60,11 @@ public class Startup
 
         // Swagger and api versioning (verified in tests)
         services
-            .AddSwaggerForWebApp(Assembly.GetExecutingAssembly(), swaggerUITitle: "ExampleHost.WebApi", swaggerUIDescription: "This is the API for ExampleHost.WebApi")
+            .AddSwaggerForWebApp(
+                Assembly.GetExecutingAssembly(),
+                swaggerUITitle: "ExampleHost.WebApi",
+                swaggerUIDescription: "This is the API for ExampleHost.WebApi",
+                useFullnameForSchemaIds: true)
 
             // Setting default version to 2.0, this will be overwritten if the method has it's own version
             .AddApiVersioningForWebApp(new ApiVersion(2, 0));

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp</PackageId>
-    <PackageVersion>14.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>14.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp/Extensions/DependencyInjection/OpenApiExtensions.cs
+++ b/source/App/source/WebApp/Extensions/DependencyInjection/OpenApiExtensions.cs
@@ -62,11 +62,13 @@ public static class OpenApiExtensions
     /// <param name="xmlCommentsFilename">Filename (with extension) of the XML file containing C# documentation comments.</param>
     /// <param name="swaggerUITitle">The title which will be display in the swagger UI, independent of the apiVersion</param>
     /// <param name="swaggerUIDescription">The API description to be displayed in the swagger UI, independent of the apiVersion</param>
+    /// <param name="useFullnameForSchemaIds"> SchemaId of types are generated from the fully qualified namespace, assembly not included</param>
     public static IServiceCollection AddSwaggerForWebApp(
         this IServiceCollection services,
         string xmlCommentsFilename,
         string swaggerUITitle,
-        string? swaggerUIDescription = null)
+        string? swaggerUIDescription = null,
+        bool useFullnameForSchemaIds = false)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(xmlCommentsFilename);
         ArgumentException.ThrowIfNullOrWhiteSpace(swaggerUITitle);
@@ -83,6 +85,11 @@ public static class OpenApiExtensions
         {
             options.SupportNonNullableReferenceTypes();
             options.UseAllOfToExtendReferenceSchemas();
+
+            if (useFullnameForSchemaIds)
+            {
+                options.CustomSchemaIds(x => x.FullName);
+            }
 
             // Set the comments path for the Swagger JSON and UI.
             // See: https://learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-8.0&tabs=visual-studio#xml-comments

--- a/source/App/source/WebApp/Extensions/DependencyInjection/OpenApiExtensions.cs
+++ b/source/App/source/WebApp/Extensions/DependencyInjection/OpenApiExtensions.cs
@@ -37,17 +37,19 @@ public static class OpenApiExtensions
     /// <param name="executingAssembly">Typically the web app assembly.</param>
     /// <param name="swaggerUITitle">The title which will be display in the swagger UI, independent of the apiVersion</param>
     /// <param name="swaggerUIDescription">The API description to be displayed in the swagger UI, independent of the apiVersion</param>
+    /// <param name="useFullnameForSchemaIds"> SchemaId of types are generated from the fully qualified namespace, assembly not included</param>
     public static IServiceCollection AddSwaggerForWebApp(
         this IServiceCollection services,
         Assembly executingAssembly,
         string swaggerUITitle,
-        string? swaggerUIDescription = null)
+        string? swaggerUIDescription = null,
+        bool useFullnameForSchemaIds = false)
     {
         ArgumentNullException.ThrowIfNull(executingAssembly);
         ArgumentException.ThrowIfNullOrWhiteSpace(swaggerUITitle);
 
         var xmlFile = $"{executingAssembly.GetName().Name}.xml";
-        services.AddSwaggerForWebApp(xmlFile, swaggerUITitle, swaggerUIDescription);
+        services.AddSwaggerForWebApp(xmlFile, swaggerUITitle, swaggerUIDescription, useFullnameForSchemaIds);
 
         return services;
     }

--- a/source/App/source/WebApp/WebApp.csproj
+++ b/source/App/source/WebApp/WebApp.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp</PackageId>
-    <PackageVersion>14.0.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>14.1.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Web App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description
This PR will address the issue with Swagger generating `SchemaIds` for class'es with the same name eg: `MeteringPoint`. 

Swagger supports full namespace when generating `SchemaIds`, which can be setup when adding the configuration.

Verified on this PR: https://github.com/Energinet-DataHub/opengeh-edi/pull/1574

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
