### PR TITLE
test: Update integration test Event Hub namespace to use new premium resource

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 8.0.1
+
+- Change `IntegrationTestConfiguration.EventHubNamespaceName` to use new (premium) Event Hub namespace.
+
 ## Version 8.0.0
 
 - Upgrade from .NET 8 to .NET 9

--- a/source/TestCommon/source/DurableFunctionApp.TestCommon/DurableFunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/DurableFunctionApp.TestCommon/DurableFunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.DurableFunctionApp.TestCommon</PackageId>
-    <PackageVersion>8.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.0.1$(VersionSuffix)</PackageVersion>
     <Title>DurableFunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/Configuration/IntegrationTestConfiguration.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/Configuration/IntegrationTestConfiguration.cs
@@ -56,7 +56,7 @@ public class IntegrationTestConfiguration
         ApplicationInsightsConnectionString = Configuration.GetValue("AZURE-APPINSIGHTS-CONNECTIONSTRING");
         LogAnalyticsWorkspaceId = Configuration.GetValue("AZURE-LOGANALYTICS-WORKSPACE-ID");
 
-        EventHubNamespaceName = Configuration.GetValue("AZURE-EVENTHUB-NAMESPACE");
+        EventHubNamespaceName = Configuration.GetValue("AZURE-EVENTHUB-NAMESPACE-PREMIUM");
         EventHubFullyQualifiedNamespace = $"{EventHubNamespaceName}.servicebus.windows.net";
         ServiceBusFullyQualifiedNamespace = $"{Configuration.GetValue("AZURE-SERVICEBUS-NAMESPACE")}.servicebus.windows.net";
 

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>8.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.0.1$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>8.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.0.1$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Updated the configuration key from "**AZURE-EVENTHUB-NAMESPACE**" to "**AZURE-EVENTHUB-NAMESPACE-PREMIUM**" in `IntegrationTestConfiguration`. This new resource enables us to have up to 100 event hubs at the same time, instead of 10 (which is the current maximum).

## Quality

- [ ] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [ ] Public types and methods are documented
- [ ] Tests are implemented and executed locally
