### PR TITLE
TestCommon: Disable Azure App Configuration provider

### DIFF
--- a/source/TestCommon/documents/release-notes/release-notes.md
+++ b/source/TestCommon/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # TestCommon Release notes
 
+## Version 8.1.1
+
+- Added const `AppConfigurationManager.DisableProviderSettingName` to be able to skip using Azure App Configuration in integration tests.
+
 ## Version 8.1.0
 
 - Added property `IntegrationTestConfiguration.AppConfigurationEndpoint` to be able to use Azure App Configuration.

--- a/source/TestCommon/source/DurableFunctionApp.TestCommon/DurableFunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/DurableFunctionApp.TestCommon/DurableFunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.DurableFunctionApp.TestCommon</PackageId>
-    <PackageVersion>8.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.1.1$(VersionSuffix)</PackageVersion>
     <Title>DurableFunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/FunctionApp.TestCommon/AppConfiguration/AppConfigurationManager.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/AppConfiguration/AppConfigurationManager.cs
@@ -31,7 +31,7 @@ public class AppConfigurationManager
     /// </summary>
     /// <remarks>
     /// Set to "true" to disable the Azure App Configuration provider
-    /// that is registered when using <code>builder.AddAzureAppConfiguration()</code>.
+    /// that is registered when using <code>IConfigurationBuilder.AddAzureAppConfiguration()</code>.
     ///
     /// See https://github.com/Azure/AppConfiguration-DotnetProvider/blob/bf8b06b9dde1bb219b625939b3d2ea00bd2a61d5/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs#L18
     /// </remarks>

--- a/source/TestCommon/source/FunctionApp.TestCommon/AppConfiguration/AppConfigurationManager.cs
+++ b/source/TestCommon/source/FunctionApp.TestCommon/AppConfiguration/AppConfigurationManager.cs
@@ -24,6 +24,19 @@ namespace Energinet.DataHub.Core.FunctionApp.TestCommon.AppConfiguration;
 /// </summary>
 public class AppConfigurationManager
 {
+    /// <summary>
+    /// Use this to disable the use of App Configuration in Azure during integration tests.
+    /// If we use Azure App Configuration in tests, parallel execution of (e.g. multiple CI's)
+    /// will impact each other. Instead we should use local settings to be in complete control.
+    /// </summary>
+    /// <remarks>
+    /// Set to "true" to disable the Azure App Configuration provider
+    /// that is registered when using <code>builder.AddAzureAppConfiguration()</code>.
+    ///
+    /// See https://github.com/Azure/AppConfiguration-DotnetProvider/blob/bf8b06b9dde1bb219b625939b3d2ea00bd2a61d5/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs#L18
+    /// </remarks>
+    public const string DisableProviderSettingName = "AZURE_APP_CONFIGURATION_PROVIDER_DISABLED";
+
     private readonly ConfigurationClient _client;
 
     public AppConfigurationManager(string appConfigEndpoint, TokenCredential credential)

--- a/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
+++ b/source/TestCommon/source/FunctionApp.TestCommon/FunctionApp.TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.FunctionApp.TestCommon</PackageId>
-    <PackageVersion>8.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.1.1$(VersionSuffix)</PackageVersion>
     <Title>FunctionApp TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/TestCommon/source/TestCommon/TestCommon.csproj
+++ b/source/TestCommon/source/TestCommon/TestCommon.csproj
@@ -31,7 +31,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.TestCommon</PackageId>
-    <PackageVersion>8.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.1.1$(VersionSuffix)</PackageVersion>
     <Title>TestCommon library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Add setting name that we can use to disable Azure App Configuration provider in integration tests

Part of: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/712

## Quality

- [ ] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [ ] Tests are implemented and executed locally
