### PR TITLE
refac: Implement a token credential factory

### DIFF
--- a/source/App/App.sln
+++ b/source/App/App.sln
@@ -61,6 +61,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "registrations", "registrati
 		documents\registrations\subsystem-authentication.md = documents\registrations\subsystem-authentication.md
 		documents\registrations\swagger-api-version.md = documents\registrations\swagger-api-version.md
 		documents\registrations\telemetry.md = documents\registrations\telemetry.md
+		documents\registrations\token-credential.md = documents\registrations\token-credential.md
 		documents\registrations\user-authorization.md = documents\registrations\user-authorization.md
 	EndProjectSection
 EndProject

--- a/source/App/documents/documentation.md
+++ b/source/App/documents/documentation.md
@@ -135,6 +135,7 @@ Features of the example:
     - Custom property `Subsystem` set to a configured value.
 - Registers health checks "live", "ready" and "status" endpoints:
     - Information returned from call to "live" endpoint contains same `AssemblyInformationalVersion` as logged to Application Insights.
+- Registers token credential that can be used to retrieve tokens for accessing Azure resources or other subsystems.
 - Registers Noda Time to its default time zone "Europe/Copenhagen".
 - Registers API Versioning and Swagger UI to the default API version `v1`.
 - Registers user authentication as documented under [User Authentication and Authorization](./registrations/user-authorization.md).
@@ -166,6 +167,7 @@ Preparing a Web App project:
    // Common
    builder.Services.AddApplicationInsightsForWebApp(subsystemName: "MySubsystem");
    builder.Services.AddHealthChecksForWebApp();
+   builder.Services.AddTokenCredentialProvider();
 
    // Would typically be registered within functional module registration methods instead of here.
    builder.Services.AddNodaTimeForApplication();

--- a/source/App/documents/documentation.md
+++ b/source/App/documents/documentation.md
@@ -19,6 +19,7 @@ Using the package bundle enables an easy opt-in/opt-out pattern of services duri
     - [Subsystem Authentication](./registrations/subsystem-authentication.md)
     - [Swagger and Api versioning](./registrations/swagger-api-version.md)
     - [Telemetry and logging to Application Insights](./registrations/telemetry.md)
+    - [Token Credential](./registrations/token-credential.md)
     - [User Authentication and Authorization](./registrations/user-authorization.md)
 
 - [Development notes for App](development.md)

--- a/source/App/documents/documentation.md
+++ b/source/App/documents/documentation.md
@@ -44,6 +44,7 @@ Features of the example:
 - Registers health checks "live", "ready" and "status" endpoints:
     - Requires the `Monitor\HealthCheckEndpoint.cs` as documented under [Health Checks](./registrations/health-checks.md#preparing-an-azure-function-app-project).
     - Information returned from call to "live" endpoint contains same `AssemblyInformationalVersion` as logged to Application Insights.
+- Registers token credential that can be used to retrieve tokens for accessing Azure resources or other subsystems.
 - Registers Noda Time to its default time zone "Europe/Copenhagen".
 - Registers Subsystem Authentication as documented under [Subsystem Authentication](./registrations/subsystem-authentication.md).
 - Register feature management with support for feature flags in app settings and Azure App Configuration.
@@ -63,6 +64,7 @@ Preparing an Azure Function App project:
            // Common
            services.AddApplicationInsightsForIsolatedWorker(subsystemName: "MySubsystem");
            services.AddHealthChecksForIsolatedWorker();
+           services.AddTokenCredentialProvider();
 
            // Http => Authentication
            services.AddSubsystemAuthenticationForIsolatedWorker(context.Configuration);

--- a/source/App/documents/documentation.md
+++ b/source/App/documents/documentation.md
@@ -46,8 +46,8 @@ Features of the example:
     - Requires the `Monitor\HealthCheckEndpoint.cs` as documented under [Health Checks](./registrations/health-checks.md#preparing-an-azure-function-app-project).
     - Information returned from call to "live" endpoint contains same `AssemblyInformationalVersion` as logged to Application Insights.
 - Registers token credential that can be used to retrieve tokens for accessing Azure resources or other subsystems.
-- Registers Noda Time to its default time zone "Europe/Copenhagen".
 - Registers Subsystem Authentication as documented under [Subsystem Authentication](./registrations/subsystem-authentication.md).
+- Registers Noda Time to its default time zone "Europe/Copenhagen".
 - Register feature management with support for feature flags in app settings and Azure App Configuration.
 
 Preparing an Azure Function App project:

--- a/source/App/documents/registrations/subsystem-authentication.md
+++ b/source/App/documents/registrations/subsystem-authentication.md
@@ -33,6 +33,7 @@ Endpoint authorization for HttpTrigger's is enforced by using the `Authorize` at
 
 As part of subsystem-to-subsystem communication the client needs to retrieve a token and send it as part of the `Authorization` header. The `Common` package contains the following code that can be used when implementing such a client:
 
+- `IdentityExtensions.AddTokenCredentialProvider()`: Registers `TokenCredentialProvider` which provides access to a token credential that is used by `AuthorizationHeaderProvider` for retrieving tokens.
 - `IdentityExtensions.AddAuthorizationHeaderProvider()`: Registers an authorization header provider as `IAuthorizationHeaderProvider`. The provider can be used to configure http clients to automatically retrieve a token and set the header during requests.
 
 For an example of implementing and registering a Http client, see `ExampleHost.FunctionApp01` and the implementation of `HttpClientExtensions.AddApp02HttpClient()`.

--- a/source/App/documents/registrations/token-credential.md
+++ b/source/App/documents/registrations/token-credential.md
@@ -24,4 +24,4 @@ To make it simple and easy to get a correct configured token credential, we have
 
 Any where we have access to `IServiceProvider` and need `TokenCredential`, we should use `TokenCredentialProvider` to get access to the registered `TokenCredential`.
 
-> If we need `TokenCredential` in a places where we haven't got `IServiceProvider` then at least always ensure to use `TokenCredentialFactory.CreateCredential()` to get an instance. This ensure we still use the best choice from a security point of view, when running in Azure.
+> If we need `TokenCredential` in a places where we haven't got `IServiceProvider` then at least always ensure to use `TokenCredentialFactory.CreateCredential()` to get an instance. This ensure we still use the best choice, from a security point of view, when running in Azure.

--- a/source/App/documents/registrations/token-credential.md
+++ b/source/App/documents/registrations/token-credential.md
@@ -1,0 +1,1 @@
+# Token Credential

--- a/source/App/documents/registrations/token-credential.md
+++ b/source/App/documents/registrations/token-credential.md
@@ -4,6 +4,7 @@
 
 - Implementation
     - [Token credential factory](#token-credential-factory)
+    - [Token credential provider](#token-credential-provider)
 
 ## Token credential factory
 

--- a/source/App/documents/registrations/token-credential.md
+++ b/source/App/documents/registrations/token-credential.md
@@ -1,1 +1,26 @@
 # Token Credential
+
+## Overview
+
+- Implementation
+    - [Token credential factory](#token-credential-factory)
+
+## Token credential factory
+
+When accessing Azure resources (like service bus) or other subsystems, we use implementations of `TokenCredential`. The token credential implementation is then used by various classes to retrieve tokens for authentication and authorization.
+
+The Azure App Services, in which we run our applications, are configured to use managed identity. So when we run in Azure we want to use the `ManagedIdentityCredential` implementation for retrieving tokens on behalf of the application.
+
+When running integration/subsystem tests locally, or in CI workflows, we want to retrieve tokens as the identity which is executing the tests (developer or service principal). So when we are not running in Azure we want to use the `DefaultAzureCredential` implementation. When creating the `DefaultAzureCredential` we disable authentication mechanisms that we know we don't use/need, because it will try all enabled authentication mechanisms and we want to save time whenever possible.
+
+To encapsulate this logic we have implemented the static `TokenCredentialFactory.CreateCredential()`.
+
+## Token credential provider
+
+In most places where we need `TokenCredential` we have access to `IServiceProvider`.
+
+To make it simple and easy to get a correct configured token credential, we have implemented the extension method `IdentityExtensions.AddTokenCredentialProvider` which registers the `TokenCredentialProvider` as singleton. The method `AddTokenCredentialProvider()` is idempotent.
+
+Any where we have access to `IServiceProvider` and need `TokenCredential`, we should use `TokenCredentialProvider` to get access to the registered `TokenCredential`.
+
+> If we need `TokenCredential` in a places where we haven't got `IServiceProvider` then at least always ensure to use `TokenCredentialFactory.CreateCredential()` to get an instance. This ensure we still use the best choice from a security point of view, when running in Azure.

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -3,13 +3,14 @@
 ## Version 15.5.0
 
 - Common package:
-    - Added functionality for sharing a token credential implementation using `TokenCredentialProvider`
-    - Implemented `IdentityExtensions.AddTokenCredentialProvider()`
-    - Refactored `IdentityExtensions.AddAuthorizationHeaderProvider()` to use `TokenCredentialProvider`
+    - Added `TokenCredentialFactory` for creating a token credential matching runtime environment
+    - Added `TokenCredentialHolder` for sharing a token credential implementation in dependency injection container
+    - Implemented `IdentityExtensions.AddTokenCredentialHolder()`
+    - Refactored `IdentityExtensions.AddAuthorizationHeaderProvider()` to use `TokenCredentialHolder`
 - FunctionApp package:
-    - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForIsolatedWorker()` to use `TokenCredentialProvider`
+    - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForIsolatedWorker()` to use `TokenCredentialFactory`
 - WebApp package:
-    - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForWebApp()` to use `TokenCredentialProvider`
+    - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForWebApp()` to use `TokenCredentialFactory`
 
 ## Version 15.4.0
 

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -1,5 +1,16 @@
 # App Release notes
 
+## Version 15.5.0
+
+- Common package:
+    - Added functionality for sharing a token credential implementation using `TokenCredentialProvider`
+    - Implemented `IdentityExtensions.AddTokenCredentialProvider()`
+    - Refactored `IdentityExtensions.AddAuthorizationHeaderProvider()` to use `TokenCredentialProvider`
+- FunctionApp package:
+    - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForIsolatedWorker()` to use `TokenCredentialProvider`
+- WebApp package:
+    - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForWebApp()` to use `TokenCredentialProvider`
+
 ## Version 15.4.0
 
 - Added functionality for Subsystem Authentication when using subsystem-to-subsystem communication:

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -6,11 +6,11 @@
     - Added `TokenCredentialFactory` for creating a token credential matching runtime environment
     - Added `TokenCredentialProvider` for sharing a token credential implementation in dependency injection container
     - Implemented `IdentityExtensions.AddTokenCredentialProvider()`
-    - Refactored `IdentityExtensions.AddAuthorizationHeaderProvider()` to use `TokenCredentialProvider`
+    - Refactored `IdentityExtensions.AddAuthorizationHeaderProvider()` to depend on `TokenCredentialProvider`
 - FunctionApp package:
-    - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForIsolatedWorker()` to use `TokenCredentialFactory`
+    - Internal refactoring of `ConfigurationBuilderExtensions.AddAzureAppConfigurationForIsolatedWorker()` to use `TokenCredentialFactory`
 - WebApp package:
-    - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForWebApp()` to use `TokenCredentialFactory`
+    - Internal refactoring of `ConfigurationBuilderExtensions.AddAzureAppConfigurationForWebApp()` to use `TokenCredentialFactory`
 
 ## Version 15.4.0
 

--- a/source/App/documents/release-notes/release-notes.md
+++ b/source/App/documents/release-notes/release-notes.md
@@ -4,9 +4,9 @@
 
 - Common package:
     - Added `TokenCredentialFactory` for creating a token credential matching runtime environment
-    - Added `TokenCredentialHolder` for sharing a token credential implementation in dependency injection container
-    - Implemented `IdentityExtensions.AddTokenCredentialHolder()`
-    - Refactored `IdentityExtensions.AddAuthorizationHeaderProvider()` to use `TokenCredentialHolder`
+    - Added `TokenCredentialProvider` for sharing a token credential implementation in dependency injection container
+    - Implemented `IdentityExtensions.AddTokenCredentialProvider()`
+    - Refactored `IdentityExtensions.AddAuthorizationHeaderProvider()` to use `TokenCredentialProvider`
 - FunctionApp package:
     - Refactored `ConfigurationBuilderExtensions.AddAzureAppConfigurationForIsolatedWorker()` to use `TokenCredentialFactory`
 - WebApp package:

--- a/source/App/source/Common.Abstractions/Common.Abstractions.csproj
+++ b/source/App/source/Common.Abstractions/Common.Abstractions.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common.Abstractions</PackageId>
-    <PackageVersion>15.4.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>15.5.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Abstractions Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common.Tests/Extensions/DependencyInjection/IdentityExtensionsTests.cs
+++ b/source/App/source/Common.Tests/Extensions/DependencyInjection/IdentityExtensionsTests.cs
@@ -30,8 +30,28 @@ public class IdentityExtensionsTests
     private ServiceCollection Services { get; }
 
     [Fact]
-    public void Given_Services_When_AddAuthorizationHeaderProvider_Then_RegistrationsArePerformed()
+    public void Given_RequiredServicesNotRegisteredAndAddAuthorizationHeaderProvider_When_GetRequiredService_Then_ThrowsException()
     {
+        // Arrange
+        Services.AddAuthorizationHeaderProvider();
+
+        var serviceProvider = Services.BuildServiceProvider();
+
+        // Act
+        var act = () => serviceProvider.GetRequiredService<IAuthorizationHeaderProvider>();
+
+        // Assert
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("No service for type 'Energinet.DataHub.Core.App.Common.Identity.TokenCredentialProvider' has been registered*");
+    }
+
+    [Fact]
+    public void Given_RequiredServices_When_AddAuthorizationHeaderProvider_Then_RegistrationsArePerformed()
+    {
+        // Arrange
+        Services.AddTokenCredentialProvider();
+
         // Act
         Services.AddAuthorizationHeaderProvider();
 
@@ -43,9 +63,10 @@ public class IdentityExtensionsTests
     }
 
     [Fact]
-    public void Given_AddAuthorizationHeaderProviderWasCalled_When_AddAuthorizationHeaderProvider_Then_RegistrationsArePerformedOnlyOnce()
+    public void Given_RequiredServicesAndAddAuthorizationHeaderProviderWasCalled_When_AddAuthorizationHeaderProvider_Then_RegistrationsArePerformedOnlyOnce()
     {
         // Arrange
+        Services.AddTokenCredentialProvider();
         Services.AddAuthorizationHeaderProvider();
 
         // Act

--- a/source/App/source/Common.Tests/Extensions/DependencyInjection/IdentityExtensionsTests.cs
+++ b/source/App/source/Common.Tests/Extensions/DependencyInjection/IdentityExtensionsTests.cs
@@ -29,6 +29,41 @@ public class IdentityExtensionsTests
 
     private ServiceCollection Services { get; }
 
+    #region AddTokenCredentialProvider
+
+    [Fact]
+    public void Given_Services_When_AddTokenCredentialProvider_Then_RegistrationsArePerformed()
+    {
+        // Act
+        Services.AddTokenCredentialProvider();
+
+        // Assert
+        var serviceProvider = Services.BuildServiceProvider();
+
+        var actual = serviceProvider.GetRequiredService<TokenCredentialProvider>();
+        actual.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Given_AddTokenCredentialProviderWasCalled_When_AddTokenCredentialProvider_Then_RegistrationsArePerformedOnlyOnce()
+    {
+        // Arrange
+        Services.AddTokenCredentialProvider();
+
+        // Act
+        Services.AddTokenCredentialProvider();
+
+        // Assert
+        var serviceProvider = Services.BuildServiceProvider();
+
+        var actual = serviceProvider.GetServices<TokenCredentialProvider>();
+        actual.Count().Should().Be(1);
+    }
+
+    #endregion
+
+    #region AddAuthorizationHeaderProvider
+
     [Fact]
     public void Given_RequiredServicesNotRegisteredAndAddAuthorizationHeaderProvider_When_GetRequiredService_Then_ThrowsException()
     {
@@ -58,8 +93,8 @@ public class IdentityExtensionsTests
         // Assert
         var serviceProvider = Services.BuildServiceProvider();
 
-        var actualAuthorizationHeaderProvider = serviceProvider.GetRequiredService<IAuthorizationHeaderProvider>();
-        actualAuthorizationHeaderProvider.Should().NotBeNull();
+        var actual = serviceProvider.GetRequiredService<IAuthorizationHeaderProvider>();
+        actual.Should().NotBeNull();
     }
 
     [Fact]
@@ -75,7 +110,9 @@ public class IdentityExtensionsTests
         // Assert
         var serviceProvider = Services.BuildServiceProvider();
 
-        var actualAuthorizationHeaderProviders = serviceProvider.GetServices<IAuthorizationHeaderProvider>();
-        actualAuthorizationHeaderProviders.Count().Should().Be(1);
+        var actual = serviceProvider.GetServices<IAuthorizationHeaderProvider>();
+        actual.Count().Should().Be(1);
     }
+
+    #endregion
 }

--- a/source/App/source/Common.Tests/Identity/AuthorizationHeaderProviderTests.cs
+++ b/source/App/source/Common.Tests/Identity/AuthorizationHeaderProviderTests.cs
@@ -41,20 +41,4 @@ public class AuthorizationHeaderProviderTests
         var token = tokenhandler.ReadJwtToken(actual.Parameter);
         token.Audiences.Should().Contain(SubsystemAuthenticationOptionsForTests.ApplicationIdUri);
     }
-
-    [Fact(Skip = "This test is not consistently true, because the test might run at a time where the token is refreshed on the CI environment.")]
-    public async Task Given_ReusedSutInstance_When_CreateAuthorizationHeaderIsCalledMultipleTimes_Then_ReturnedHeaderContainsSameTokenBecauseTokenCacheIsUsed()
-    {
-        // Arrange
-        var credential = new DefaultAzureCredential();
-        var sut = new AuthorizationHeaderProvider(credential);
-
-        // Act
-        var header01 = sut.CreateAuthorizationHeader(SubsystemAuthenticationOptionsForTests.ApplicationIdUri);
-        await Task.Delay(TimeSpan.FromSeconds(1));
-        var header02 = sut.CreateAuthorizationHeader(SubsystemAuthenticationOptionsForTests.ApplicationIdUri);
-
-        // Assert
-        header01.Parameter.Should().Be(header02.Parameter);
-    }
 }

--- a/source/App/source/Common.Tests/Identity/TokenCredentialFactoryTests.cs
+++ b/source/App/source/Common.Tests/Identity/TokenCredentialFactoryTests.cs
@@ -18,13 +18,13 @@ using Xunit;
 
 namespace Energinet.DataHub.Core.App.Common.Tests.Identity;
 
-public sealed class TokenCredentialProviderTests : IDisposable
+public sealed class TokenCredentialFactoryTests : IDisposable
 {
     private const string WebsiteInstanceId = "test-instance-id";
 
     private readonly string? _originalWebsiteInstanceId;
 
-    public TokenCredentialProviderTests()
+    public TokenCredentialFactoryTests()
     {
         // Save the original environment variable to restore after test
         _originalWebsiteInstanceId = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID");
@@ -37,47 +37,28 @@ public sealed class TokenCredentialProviderTests : IDisposable
     }
 
     [Fact]
-    public void Given_RunningInAzure_When_Credential_Then_ReturnsManagedIdentityCredential()
+    public void Given_RunningInAzure_When_CreateCredential_Then_ReturnsManagedIdentityCredential()
     {
         // Arrange
         Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", WebsiteInstanceId);
 
-        var sut = new TokenCredentialProvider();
-
         // Act
-        var credential = sut.Credential;
+        var credential = TokenCredentialFactory.CreateCredential();
 
         // Assert
         Assert.IsType<ManagedIdentityCredential>(credential);
     }
 
     [Fact]
-    public void Given_NotRunningInAzure_When_Credential_Then_ReturnsDefaultAzureCredential()
+    public void Given_NotRunningInAzure_When_CreateCredential_Then_ReturnsDefaultAzureCredential()
     {
         // Arrange
         Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
 
-        var sut = new TokenCredentialProvider();
-
         // Act
-        var credential = sut.Credential;
+        var credential = TokenCredentialFactory.CreateCredential();
 
         // Assert
         Assert.IsType<DefaultAzureCredential>(credential);
-    }
-
-    [Fact]
-    public void Given_NotAccessedYet_When_CredentialIsAccessedMultipleTimes_Then_CredentialIsLazyInitialized()
-    {
-        // Arrange
-        Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
-        var sut = new TokenCredentialProvider();
-
-        // Act
-        var firstCredential = sut.Credential;
-        var secondCredential = sut.Credential;
-
-        // Assert
-        Assert.Same(firstCredential, secondCredential);
     }
 }

--- a/source/App/source/Common.Tests/Identity/TokenCredentialProviderTests.cs
+++ b/source/App/source/Common.Tests/Identity/TokenCredentialProviderTests.cs
@@ -1,0 +1,83 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure.Identity;
+using Energinet.DataHub.Core.App.Common.Identity;
+using Xunit;
+
+namespace Energinet.DataHub.Core.App.Common.Tests.Identity;
+
+public sealed class TokenCredentialProviderTests : IDisposable
+{
+    private const string WebsiteInstanceId = "test-instance-id";
+
+    private readonly string? _originalWebsiteInstanceId;
+
+    public TokenCredentialProviderTests()
+    {
+        // Save the original environment variable to restore after test
+        _originalWebsiteInstanceId = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID");
+    }
+
+    public void Dispose()
+    {
+        // Restore the original environment variable
+        Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", _originalWebsiteInstanceId);
+    }
+
+    [Fact]
+    public void Given_RunningInAzure_When_Credential_Then_ReturnsManagedIdentityCredential()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", WebsiteInstanceId);
+
+        var sut = new TokenCredentialProvider();
+
+        // Act
+        var credential = sut.Credential;
+
+        // Assert
+        Assert.IsType<ManagedIdentityCredential>(credential);
+    }
+
+    [Fact]
+    public void Given_NotRunningInAzure_When_Credential_Then_ReturnsDefaultAzureCredential()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
+
+        var sut = new TokenCredentialProvider();
+
+        // Act
+        var credential = sut.Credential;
+
+        // Assert
+        Assert.IsType<DefaultAzureCredential>(credential);
+    }
+
+    [Fact]
+    public void Given_NotAccessedYet_When_CredentialIsAccessedMultipleTimes_Then_CredentialIsLazyInitialized()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
+        var sut = new TokenCredentialProvider();
+
+        // Act
+        var firstCredential = sut.Credential;
+        var secondCredential = sut.Credential;
+
+        // Assert
+        Assert.Same(firstCredential, secondCredential);
+    }
+}

--- a/source/App/source/Common/Common.csproj
+++ b/source/App/source/Common/Common.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.Common</PackageId>
-    <PackageVersion>15.4.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>15.5.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function Common Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
+++ b/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
@@ -25,10 +25,8 @@ public static class IdentityExtensions
     /// Add a token credential provider that can be used to retrieve a
     /// shared <see cref="TokenCredential"/> implementation.
     /// </summary>
-    public static IServiceCollection AddTokenCredentialProvider(this IServiceCollection services)
+    public static IServiceCollection AddTokenCredentialHolder(this IServiceCollection services)
     {
-        // TODO: Create the TokenCredential right away, and return the instance.
-        // This is similar to .NET Aspire AddAzureStorage() which also returns<,> see https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-aspire-integration#azure-functions-host-storage
         services.TryAddSingleton<TokenCredentialProvider>();
         return services;
     }

--- a/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
+++ b/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
@@ -25,7 +25,7 @@ public static class IdentityExtensions
     /// Add a token credential provider that can be used to retrieve a
     /// shared <see cref="TokenCredential"/> implementation.
     /// </summary>
-    public static IServiceCollection AddTokenCredentialHolder(this IServiceCollection services)
+    public static IServiceCollection AddTokenCredentialProvider(this IServiceCollection services)
     {
         services.TryAddSingleton<TokenCredentialProvider>();
         return services;

--- a/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
+++ b/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
@@ -26,41 +26,9 @@ public static class IdentityExtensions
     /// Add a token credential provider that can be used to retrieve a
     /// shared <see cref="TokenCredential"/> implementation.
     /// </summary>
-    /// <remarks>
-    /// The actual token credential implementation registered will depend on whether
-    /// the application is running in an Azure App Service or not (e.g. locally or CI/CD runners).
-    /// </remarks>
     public static IServiceCollection AddTokenCredentialProvider(this IServiceCollection services)
     {
-        services.TryAddSingleton<TokenCredentialProvider>(sp =>
-        {
-            if (IsRunningInAzure())
-            {
-                return new TokenCredentialProvider(new ManagedIdentityCredential());
-            }
-            else
-            {
-                // As we register TokenCredentialProvider as singleton and it has the instance
-                // of DefaultAzureCredential, we expect it will use caching and handle token refresh.
-                // However the documentation is a bit unclear: https://learn.microsoft.com/da-dk/dotnet/azure/sdk/authentication/best-practices?tabs=aspdotnet#understand-when-token-lifetime-and-caching-logic-is-needed
-                var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
-                {
-                    ExcludeEnvironmentCredential = false,
-                    ExcludeVisualStudioCredential = false,
-                    ExcludeAzureCliCredential = false,
-                    // Here we disable authentication mechanisms that is not used for Integration Test environment
-                    // See also: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet#defaultazurecredential
-                    ExcludeWorkloadIdentityCredential = true,
-                    ExcludeManagedIdentityCredential = true,
-                    ExcludeVisualStudioCodeCredential = true,
-                    ExcludeAzurePowerShellCredential = true,
-                    ExcludeAzureDeveloperCliCredential = true,
-                    ExcludeInteractiveBrowserCredential = true,
-                });
-                return new TokenCredentialProvider(credential);
-            }
-        });
-
+        services.TryAddSingleton<TokenCredentialProvider>();
         return services;
     }
 

--- a/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
+++ b/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
@@ -48,13 +48,4 @@ public static class IdentityExtensions
 
         return services;
     }
-
-    /// <summary>
-    /// Determine if application is running in Azure App Service.
-    /// </summary>
-    /// <returns><see langword="true"/> if application is running in Azure App Service; otherwise <see langword="false"/>.</returns>
-    private static bool IsRunningInAzure()
-    {
-        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"));
-    }
 }

--- a/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
+++ b/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Azure.Core;
-using Azure.Identity;
 using Energinet.DataHub.Core.App.Common.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
+++ b/source/App/source/Common/Extensions/DependencyInjection/IdentityExtensions.cs
@@ -27,6 +27,8 @@ public static class IdentityExtensions
     /// </summary>
     public static IServiceCollection AddTokenCredentialProvider(this IServiceCollection services)
     {
+        // TODO: Create the TokenCredential right away, and return the instance.
+        // This is similar to .NET Aspire AddAzureStorage() which also returns<,> see https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-aspire-integration#azure-functions-host-storage
         services.TryAddSingleton<TokenCredentialProvider>();
         return services;
     }

--- a/source/App/source/Common/Identity/TokenCredentialFactory.cs
+++ b/source/App/source/Common/Identity/TokenCredentialFactory.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure.Core;
+using Azure.Identity;
+
+namespace Energinet.DataHub.Core.App.Common.Identity;
+
+public static class TokenCredentialFactory
+{
+    /// <summary>
+    /// Always use this factory method to create an implementation of <see cref="TokenCredential"/>.
+    /// The actual token credential implementation created will depend on whether
+    /// the application is running in an Azure App Service or not (e.g. locally or CI/CD runners).
+    /// </summary>
+    public static TokenCredential CreateCredential()
+    {
+        if (IsRunningInAzure())
+        {
+            return new ManagedIdentityCredential();
+        }
+        else
+        {
+            // We expect DefaultAzureCredential uses caching and handles token refresh.
+            // However the documentation is a bit unclear: https://learn.microsoft.com/da-dk/dotnet/azure/sdk/authentication/best-practices?tabs=aspdotnet#understand-when-token-lifetime-and-caching-logic-is-needed
+            return new DefaultAzureCredential(new DefaultAzureCredentialOptions
+            {
+                ExcludeEnvironmentCredential = false,
+                ExcludeVisualStudioCredential = false,
+                ExcludeAzureCliCredential = false,
+                // Here we disable authentication mechanisms that is not used for development
+                // See also: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet#defaultazurecredential
+                ExcludeWorkloadIdentityCredential = true,
+                ExcludeManagedIdentityCredential = true,
+                ExcludeVisualStudioCodeCredential = true,
+                ExcludeAzurePowerShellCredential = true,
+                ExcludeAzureDeveloperCliCredential = true,
+                ExcludeInteractiveBrowserCredential = true,
+            });
+        }
+    }
+
+    /// <summary>
+    /// Here we detect if there is a system defined environment variable available;
+    /// if "true" we know this is running on a VM in Azure.
+    /// </summary>
+    private static bool IsRunningInAzure()
+    {
+        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"));
+    }
+}

--- a/source/App/source/Common/Identity/TokenCredentialProvider.cs
+++ b/source/App/source/Common/Identity/TokenCredentialProvider.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure.Core;
+
+namespace Energinet.DataHub.Core.App.Common.Identity;
+
+/// <summary>
+/// We use this provider to be able to register an implementation of
+/// <see cref="TokenCredential"/> without registering the type directly.
+/// </summary>
+public sealed class TokenCredentialProvider
+{
+    private readonly TokenCredential _credential;
+
+    internal TokenCredentialProvider(TokenCredential credential)
+    {
+        _credential = credential;
+    }
+
+    /// <summary>
+    /// Represents a credential capable of providing an OAuth token.
+    /// </summary>
+    public TokenCredential Credential => _credential;
+}

--- a/source/App/source/Common/Identity/TokenCredentialProvider.cs
+++ b/source/App/source/Common/Identity/TokenCredentialProvider.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Azure.Core;
-using Azure.Identity;
 
 namespace Energinet.DataHub.Core.App.Common.Identity;
 
@@ -21,45 +20,12 @@ namespace Energinet.DataHub.Core.App.Common.Identity;
 /// We use this provider to be able to create an implementation of
 /// <see cref="TokenCredential"/> without registering the type directly.
 /// </summary>
-/// <remarks>
-/// The actual token credential implementation created will depend on whether
-/// the application is running in an Azure App Service or not (e.g. locally or CI/CD runners).
-/// </remarks>
 public sealed class TokenCredentialProvider
 {
-    private readonly Lazy<TokenCredential> _credential = new(CreateCredential, isThreadSafe: true);
-
-    public TokenCredential Credential => _credential.Value;
-
-    private static TokenCredential CreateCredential()
+    public TokenCredentialProvider()
     {
-        if (IsRunningInAzure())
-        {
-            return new ManagedIdentityCredential();
-        }
-        else
-        {
-            // We expect DefaultAzureCredential uses caching and handles token refresh.
-            // However the documentation is a bit unclear: https://learn.microsoft.com/da-dk/dotnet/azure/sdk/authentication/best-practices?tabs=aspdotnet#understand-when-token-lifetime-and-caching-logic-is-needed
-            return new DefaultAzureCredential(new DefaultAzureCredentialOptions
-            {
-                ExcludeEnvironmentCredential = false,
-                ExcludeVisualStudioCredential = false,
-                ExcludeAzureCliCredential = false,
-                // Here we disable authentication mechanisms that is not used for development
-                // See also: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet#defaultazurecredential
-                ExcludeWorkloadIdentityCredential = true,
-                ExcludeManagedIdentityCredential = true,
-                ExcludeVisualStudioCodeCredential = true,
-                ExcludeAzurePowerShellCredential = true,
-                ExcludeAzureDeveloperCliCredential = true,
-                ExcludeInteractiveBrowserCredential = true,
-            });
-        }
+        Credential = TokenCredentialFactory.CreateCredential();
     }
 
-    private static bool IsRunningInAzure()
-    {
-        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"));
-    }
+    public TokenCredential Credential { get; }
 }

--- a/source/App/source/ExampleHost.FunctionApp.Tests/Fixtures/ExampleHostsFixture.cs
+++ b/source/App/source/ExampleHost.FunctionApp.Tests/Fixtures/ExampleHostsFixture.cs
@@ -47,7 +47,7 @@ public class ExampleHostsFixture : IAsyncLifetime
         ServiceBusResourceProvider = new ServiceBusResourceProvider(TestLogger, IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace, IntegrationTestConfiguration.Credential);
 
         HostConfigurationBuilder = new FunctionAppHostConfigurationBuilder();
-        LogsQueryClient = new LogsQueryClient(new DefaultAzureCredential());
+        LogsQueryClient = new LogsQueryClient(IntegrationTestConfiguration.Credential);
 
         OpenIdJwtManager = new OpenIdJwtManager(IntegrationTestConfiguration.B2CSettings, openIdServerPort: 1052);
 

--- a/source/App/source/ExampleHost.FunctionApp01/Program.cs
+++ b/source/App/source/ExampleHost.FunctionApp01/Program.cs
@@ -43,7 +43,7 @@ var host = new HostBuilder()
         // Configure token credential provider to share token credential
         //  * Used by "AddAuthorizationHeaderProvider"
         //  * Can be used when registering access to Azure resources (e.g. service bus etc.)
-        services.AddTokenCredentialHolder();
+        services.AddTokenCredentialProvider();
 
         // Configure ServiceBusSender for calling FunctionApp02
         services.AddSingleton(sp =>

--- a/source/App/source/ExampleHost.FunctionApp01/Program.cs
+++ b/source/App/source/ExampleHost.FunctionApp01/Program.cs
@@ -41,7 +41,7 @@ var host = new HostBuilder()
         services.AddApplicationInsightsForIsolatedWorker(subsystemName: "ExampleHost.FunctionApp");
 
         // Configure token credential provider to share token credential
-        //  * Retrieved by Subsystem Authentication
+        //  * Used by "AddAuthorizationHeaderProvider"
         //  * Can be used when registering access to Azure resources (e.g. service bus etc.)
         services.AddTokenCredentialHolder();
 

--- a/source/App/source/ExampleHost.FunctionApp01/Program.cs
+++ b/source/App/source/ExampleHost.FunctionApp01/Program.cs
@@ -78,6 +78,7 @@ var host = new HostBuilder()
             .AddFeatureManagement();
 
         // Http => Client side subsystem-to-subsystem authentication (verified in tests)
+        //  * Depends on services registered by "AddTokenCredentialProvider"
         services
             .AddAuthorizationHeaderProvider()
             .AddApp02HttpClient();

--- a/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
@@ -55,12 +55,6 @@ public class ExampleHostFixture : IAsyncLifetime
             .UseUrls(web02BaseUrl)
             .Build();
 
-        var webHost01Builder = WebHost.CreateDefaultBuilder();
-        webHost01Builder.ConfigureServices(services =>
-        {
-            services.
-        });
-
         Web01Host = WebHost.CreateDefaultBuilder()
             .ConfigureAppConfiguration((context, configBuilder) =>
             {

--- a/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
@@ -55,6 +55,7 @@ public class ExampleHostFixture : IAsyncLifetime
             .UseUrls(web02BaseUrl)
             .Build();
 
+        var webHost01Builder = WebHost.CreateDefaultBuilder();
         Web01Host = WebHost.CreateDefaultBuilder()
             .ConfigureAppConfiguration((context, configBuilder) =>
             {

--- a/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
@@ -56,6 +56,11 @@ public class ExampleHostFixture : IAsyncLifetime
             .Build();
 
         var webHost01Builder = WebHost.CreateDefaultBuilder();
+        webHost01Builder.ConfigureServices(services =>
+        {
+            services.
+        });
+
         Web01Host = WebHost.CreateDefaultBuilder()
             .ConfigureAppConfiguration((context, configBuilder) =>
             {

--- a/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
+++ b/source/App/source/ExampleHost.WebApi.Tests/Fixtures/ExampleHostFixture.cs
@@ -86,7 +86,7 @@ public class ExampleHostFixture : IAsyncLifetime
             BaseAddress = new Uri(web01BaseUrl),
         };
 
-        LogsQueryClient = new LogsQueryClient(new DefaultAzureCredential());
+        LogsQueryClient = new LogsQueryClient(IntegrationTestConfiguration.Credential);
     }
 
     public AppConfigurationManager AppConfigurationManager { get; }

--- a/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -44,7 +44,9 @@ public static class ConfigurationBuilderExtensions
         configBuilder.AddAzureAppConfiguration(options =>
         {
             options
-                .Connect(new Uri(appConfigurationOptions.Endpoint), credential ?? TokenCredentialFactory.CreateCredential())
+                .Connect(
+                    new Uri(appConfigurationOptions.Endpoint),
+                    credential ?? TokenCredentialFactory.CreateCredential())
                 // Using dummy key "_" to avoid loading other configuration than feature flags
                 .Select("_")
                 // Load all feature flags with no label.

--- a/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -44,7 +44,7 @@ public static class ConfigurationBuilderExtensions
         configBuilder.AddAzureAppConfiguration(options =>
         {
             options
-                .Connect(new Uri(appConfigurationOptions.Endpoint), credential ?? new TokenCredentialProvider().Credential)
+                .Connect(new Uri(appConfigurationOptions.Endpoint), credential ?? TokenCredentialFactory.CreateCredential())
                 // Using dummy key "_" to avoid loading other configuration than feature flags
                 .Select("_")
                 // Load all feature flags with no label.

--- a/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class ConfigurationBuilderExtensions
     /// <remarks>
     /// Expects <see cref="AzureAppConfigurationOptions"/> has been configured in <see cref="AzureAppConfigurationOptions.SectionName"/>.
     /// </remarks>
-    public static IConfigurationBuilder AddAzureAppConfigurationForIsolatedWorker(this IConfigurationBuilder configBuilder, TokenCredential? azureCredential = null)
+    public static IConfigurationBuilder AddAzureAppConfigurationForIsolatedWorker(this IConfigurationBuilder configBuilder, TokenCredential? credential = null)
     {
         var configuration = configBuilder.Build();
         var appConfigurationOptions = configuration
@@ -45,7 +45,7 @@ public static class ConfigurationBuilderExtensions
         configBuilder.AddAzureAppConfiguration(options =>
         {
             options
-                .Connect(new Uri(appConfigurationOptions.Endpoint), azureCredential ?? new DefaultAzureCredential())
+                .Connect(new Uri(appConfigurationOptions.Endpoint), credential ?? new TokenCredentialProvider().Credential)
                 // Using dummy key "_" to avoid loading other configuration than feature flags
                 .Select("_")
                 // Load all feature flags with no label.

--- a/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -15,6 +15,7 @@
 using Azure.Core;
 using Azure.Identity;
 using Energinet.DataHub.Core.App.Common.Extensions.Options;
+using Energinet.DataHub.Core.App.Common.Identity;
 using Microsoft.Extensions.Configuration;
 
 namespace Energinet.DataHub.Core.App.FunctionApp.Extensions.Builder;
@@ -27,9 +28,10 @@ public static class ConfigurationBuilderExtensions
 {
     /// <summary>
     /// Configures use of Azure App Configuration for feature flags only.
-    ///
-    /// Expects <see cref="AzureAppConfigurationOptions"/> has been configured in <see cref="AzureAppConfigurationOptions.SectionName"/>.
     /// </summary>
+    /// <remarks>
+    /// Expects <see cref="AzureAppConfigurationOptions"/> has been configured in <see cref="AzureAppConfigurationOptions.SectionName"/>.
+    /// </remarks>
     public static IConfigurationBuilder AddAzureAppConfigurationForIsolatedWorker(this IConfigurationBuilder configBuilder, TokenCredential? azureCredential = null)
     {
         var configuration = configBuilder.Build();

--- a/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/FunctionApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Azure.Core;
-using Azure.Identity;
 using Energinet.DataHub.Core.App.Common.Extensions.Options;
 using Energinet.DataHub.Core.App.Common.Identity;
 using Microsoft.Extensions.Configuration;

--- a/source/App/source/FunctionApp/FunctionApp.csproj
+++ b/source/App/source/FunctionApp/FunctionApp.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.FunctionApp</PackageId>
-    <PackageVersion>15.4.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>15.5.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Function App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class ConfigurationBuilderExtensions
     /// <remarks>
     /// Expects <see cref="AzureAppConfigurationOptions"/> has been configured in <see cref="AzureAppConfigurationOptions.SectionName"/>.
     /// </remarks>
-    public static IConfigurationBuilder AddAzureAppConfigurationForWebApp(this IConfigurationBuilder configBuilder, IConfiguration configuration, TokenCredential? azureCredential = null)
+    public static IConfigurationBuilder AddAzureAppConfigurationForWebApp(this IConfigurationBuilder configBuilder, IConfiguration configuration, TokenCredential? credential = null)
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
@@ -46,7 +46,7 @@ public static class ConfigurationBuilderExtensions
         configBuilder.AddAzureAppConfiguration(options =>
         {
             options
-                .Connect(new Uri(appConfigurationOptions.Endpoint), azureCredential ?? new DefaultAzureCredential())
+                .Connect(new Uri(appConfigurationOptions.Endpoint), credential ?? new TokenCredentialProvider().Credential)
                 // Using dummy key "_" to avoid loading other configuration than feature flags
                 .Select("_")
                 // Load all feature flags with no label.

--- a/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -15,6 +15,7 @@
 using Azure.Core;
 using Azure.Identity;
 using Energinet.DataHub.Core.App.Common.Extensions.Options;
+using Energinet.DataHub.Core.App.Common.Identity;
 using Microsoft.Extensions.Configuration;
 
 namespace Energinet.DataHub.Core.App.WebApp.Extensions.Builder;
@@ -27,9 +28,10 @@ public static class ConfigurationBuilderExtensions
 {
     /// <summary>
     /// Configures use of Azure App Configuration for feature flags only.
-    ///
-    /// Expects <see cref="AzureAppConfigurationOptions"/> has been configured in <see cref="AzureAppConfigurationOptions.SectionName"/>.
     /// </summary>
+    /// <remarks>
+    /// Expects <see cref="AzureAppConfigurationOptions"/> has been configured in <see cref="AzureAppConfigurationOptions.SectionName"/>.
+    /// </remarks>
     public static IConfigurationBuilder AddAzureAppConfigurationForWebApp(this IConfigurationBuilder configBuilder, IConfiguration configuration, TokenCredential? azureCredential = null)
     {
         ArgumentNullException.ThrowIfNull(configuration);

--- a/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -45,7 +45,9 @@ public static class ConfigurationBuilderExtensions
         configBuilder.AddAzureAppConfiguration(options =>
         {
             options
-                .Connect(new Uri(appConfigurationOptions.Endpoint), credential ?? TokenCredentialFactory.CreateCredential())
+                .Connect(
+                    new Uri(appConfigurationOptions.Endpoint),
+                    credential ?? TokenCredentialFactory.CreateCredential())
                 // Using dummy key "_" to avoid loading other configuration than feature flags
                 .Select("_")
                 // Load all feature flags with no label.

--- a/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -45,7 +45,7 @@ public static class ConfigurationBuilderExtensions
         configBuilder.AddAzureAppConfiguration(options =>
         {
             options
-                .Connect(new Uri(appConfigurationOptions.Endpoint), credential ?? new TokenCredentialProvider().Credential)
+                .Connect(new Uri(appConfigurationOptions.Endpoint), credential ?? TokenCredentialFactory.CreateCredential())
                 // Using dummy key "_" to avoid loading other configuration than feature flags
                 .Select("_")
                 // Load all feature flags with no label.

--- a/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
+++ b/source/App/source/WebApp/Extensions/Builder/ConfigurationBuilderExtensions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Azure.Core;
-using Azure.Identity;
 using Energinet.DataHub.Core.App.Common.Extensions.Options;
 using Energinet.DataHub.Core.App.Common.Identity;
 using Microsoft.Extensions.Configuration;

--- a/source/App/source/WebApp/WebApp.csproj
+++ b/source/App/source/WebApp/WebApp.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Core.App.WebApp</PackageId>
-    <PackageVersion>15.4.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>15.5.0$(VersionSuffix)</PackageVersion>
     <Title>Azure Web App Library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Implement `TokenCredentialFactory` so we encapsulate the creation of token credentials, and avoid instantiating `DefaultAzureCredential` when running in Azure.

Implement `TokenCredentialProvider` and matching extension `TokenCredentialProvider`. The `TokenCredentialProvider` uses `TokenCredentialFactory` to create the token credential it provides. By registering `TokenCredentialProvider` other service registration extension can easily get access to `TokenCredentialProvider` and its `Credential`. Thereby we can reduce the places where we might otherwise create separate token credential instanses.

Part of: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/402

## Quality

- [x] Documentation is updated
- [x] Release notes are updated
- [x] Package version is updated
- [x] Public types and methods are documented
- [x] Tests are implemented and executed locally
